### PR TITLE
Derive the advertised GeoServer URL from the configured host port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@ GEOSERVER_USER=admin
 GEOSERVER_PASS=geoserver
 
 # Host port overrides (container ports are unchanged). Set these if the defaults
-# collide with other stacks on the host.
+# collide with other stacks on the host. GEOSERVER_HOST_PORT also determines the
+# GeoServer URL the WPS advertises to clients for published layers.
 WPS_HOST_PORT=5000
 DASHBOARD_HOST_PORT=8000
 FILESERVER_HOST_PORT=8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       - gisdata:/gisdata
     environment:
       GEOSERVER_URL: http://geoserver:8080/geoserver
-      GEOSERVER_PUBLIC_URL: http://localhost:8080/geoserver
+      # Advertised to WPS clients in the WMS URLs of published layers, so it has
+      # to follow the host mapping below -- not the container port.
+      GEOSERVER_PUBLIC_URL: http://localhost:${GEOSERVER_HOST_PORT:-8080}/geoserver
       GEOSERVER_USER: ${GEOSERVER_USER:-admin}
       GEOSERVER_PASS: ${GEOSERVER_PASS:-geoserver}
       WPS_WORKSPACE_PREFIX: esws-


### PR DESCRIPTION
Follow-up to #32.

That PR parameterized the host-side port mappings, but `GEOSERVER_PUBLIC_URL` stayed pinned to `localhost:8080`:

```yaml
ports:
  - "${GEOSERVER_HOST_PORT:-8080}:8080"
...
GEOSERVER_PUBLIC_URL: http://localhost:8080/geoserver   # not parameterized
```

That value isn't cosmetic. `tools/wpsserver/wpsprocess/invest_models.py:194` uses it as the base of the WMS `GetMap` URLs returned to WPS clients for every published layer:

```python
gs_url = os.environ.get("GEOSERVER_PUBLIC_URL", ...)
layer_urls = ["%s/wms?service=WMS&...&layers=%s" % (gs_url, ln) for ln in published]
```

So on exactly the hosts #32 exists to serve — the ones where 8080 is already taken — every model run hands back links pointing at whichever unrelated service occupies 8080. On the machine this surfaced on, that's an unrelated frontend container.

The in-network `GEOSERVER_URL` was already correct and is untouched: it addresses the container port over the compose network.

**Verified** with `docker compose config` and `GEOSERVER_HOST_PORT=8085`:

```
GEOSERVER_PUBLIC_URL: http://localhost:8085/geoserver
GEOSERVER_URL: http://geoserver:8080/geoserver
published: "8085" -> target: 8080
```

Note the hostname stays `localhost`, which is still only right for clients on the Docker host — unchanged from before, and a separate question from the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG