### PR TITLE
Build the shared app image once instead of three times concurrently

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,11 @@ services:
       - geoserver
 
   fileserver:
+    # Shares the wps image. Only the wps service declares the build: buildkit
+    # builds compose services concurrently, so repeating the same build/image
+    # pair here made three builders export the tag at once, which races and
+    # fails the whole build with `image "esws/wps:latest": already exists`.
     image: esws/wps
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.invest
     command: python tools/http_server.py
     ports:
       - "${FILESERVER_HOST_PORT:-8001}:8001"
@@ -44,10 +45,7 @@ services:
       - gisdata:/gisdata
 
   dashboard:
-    image: esws/wps
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.invest
+    image: esws/wps  # see fileserver
     command: >
       sh -c "python tools/wpsclient/manage.py migrate --run-syncdb &&
              python tools/wpsclient/manage.py runserver 0.0.0.0:8000"


### PR DESCRIPTION
`make smoke` fails on a cold cache. Found while verifying the stack still runs.

## The failure

`wps`, `fileserver` and `dashboard` all run the same `esws/wps` image, and all three declared the same `build:` stanza. Compose hands those to buildkit concurrently, so three builders race to export one tag:

```
#14 [dashboard] exporting to image
#14 naming to docker.io/esws/wps:latest 0.0s done
#14 ERROR: image "docker.io/esws/wps:latest": already exists
#13 [wps] ... CANCELED
#12 [fileserver] ... CANCELED
------
target dashboard: failed to solve: image "docker.io/esws/wps:latest": already exists
```

`docker compose build` exits non-zero, so `scripts/smoke.sh` aborts under `set -e` before the stack ever starts.

What makes this easy to miss: the race still leaves a usable `esws/wps` image behind, so the *next* build hits cache and looks fine. It only bites a fresh clone or a pruned cache — which is exactly when someone is most likely to be trying the project for the first time.

## The fix

Declare the build once, on `wps`. The other two services reference `image: esws/wps` with no build section, so `docker compose build` produces it a single time and `up` reuses the local image.

## Verification

With the tag deleted so the export stage actually re-runs:

```
$ docker compose config | grep -c 'dockerfile:'
1
$ docker rmi -f esws/wps:latest && docker compose build
 esws/wps  Built            # 38s, single export, no race

$ ./scripts/smoke.sh
tests/test_dashboard.py::test_dashboard_home PASSED                      [ 14%]
tests/test_dashboard.py::test_dashboard_server_list PASSED               [ 28%]
tests/test_dashboard.py::test_dashboard_job_list PASSED                  [ 42%]
tests/test_invest_smoke.py::test_carbon_executes_and_publishes PASSED    [ 57%]
tests/test_wps_capabilities.py::test_getcapabilities_lists_all_invest_models PASSED [ 71%]
tests/test_wps_capabilities.py::test_describeprocess_carbon_exposes_spec_args PASSED [ 85%]
tests/test_wps_capabilities.py::test_echo_execute_roundtrips PASSED      [100%]
======================== 7 passed, 3 warnings in 40.71s ========================
```

Touches the same file as #34 but different lines; they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG