### PR TITLE
Describe every model, not just carbon

### DIFF
--- a/tests/test_wps_capabilities.py
+++ b/tests/test_wps_capabilities.py
@@ -1,9 +1,11 @@
 """WPS-server smoke tests that do not require GeoServer.
 
 Validates the generalized middleware: GetCapabilities should advertise every
-importable InVEST model, DescribeProcess should expose a model's MODEL_SPEC args,
-and the echo process should round-trip.
+importable InVEST model, DescribeProcess should render every one of those specs
+(and expose the expected args for a known model), the runner-only arguments
+should stay hidden, and the echo process should round-trip.
 """
+import pytest
 import requests
 from owslib.wps import WebProcessingService
 
@@ -40,6 +42,58 @@ def test_getcapabilities_lists_all_invest_models(wps_url):
     # legacy + echo processes still present
     assert "echo_string" in advertised
     assert "natcap.invest.hydropower.hydropower_water_yield" in advertised
+
+
+@pytest.fixture(scope="module")
+def described_models(wps_url):
+    """{model_id: set of input identifiers} for every advertised InVEST model.
+
+    Describing 25 models is the expensive part, so it happens once here and the
+    tests below share the result. A model that fails to describe is stored as
+    its exception rather than raised, so one bad spec reports as a single test
+    failure listing every offender instead of aborting the fixture.
+    """
+    wps = WebProcessingService(wps_url, version="1.0.0")
+    described = {}
+    for model_id in sorted(_expected_model_ids()):
+        try:
+            proc = wps.describeprocess(model_id)
+            described[model_id] = {i.identifier for i in proc.dataInputs}
+        except Exception as exc:  # noqa: BLE001 - asserted on below
+            described[model_id] = exc
+    return described
+
+
+def test_describeprocess_succeeds_for_every_model(described_models):
+    """GetCapabilities only proves each process got registered. MODEL_SPEC is
+    not translated into WPS inputs until DescribeProcess, so a spec the wrapper
+    cannot render is invisible until then -- which matters because the model
+    set moves with every InVEST upgrade."""
+    # Guard against a vacuous pass: an empty registry would satisfy every
+    # assertion below without describing anything.
+    assert len(described_models) >= 20, \
+        "expected the full InVEST registry, got %d" % len(described_models)
+
+    broken = {m: repr(r) for m, r in described_models.items()
+              if isinstance(r, Exception)}
+    assert not broken, "DescribeProcess failed for: %s" % broken
+
+    empty = sorted(m for m, r in described_models.items() if not r)
+    assert not empty, "no inputs advertised for: %s" % empty
+
+
+def test_runner_args_hidden_but_results_suffix_exposed(described_models):
+    """workspace_dir and n_workers are managed by the wrapper and must never be
+    client-settable. results_suffix deliberately is -- docsrc/models.rst tells
+    readers so, and this keeps that claim honest."""
+    hidden = {"workspace_dir", "n_workers"}
+    leaked = {m: sorted(hidden & r) for m, r in described_models.items()
+              if not isinstance(r, Exception) and hidden & r}
+    assert not leaked, "runner-only args exposed as WPS inputs: %s" % leaked
+
+    missing = sorted(m for m, r in described_models.items()
+                     if not isinstance(r, Exception) and "results_suffix" not in r)
+    assert not missing, "results_suffix not exposed by: %s" % missing
 
 
 def test_describeprocess_carbon_exposes_spec_args(wps_url):


### PR DESCRIPTION
A coverage gap found while verifying the merged stack.

`test_getcapabilities_lists_all_invest_models` proves all 25 models are *registered*, but `MODEL_SPEC` isn't translated into WPS inputs until `DescribeProcess` — and only `carbon` was ever described. A model whose spec the wrapper can't render would advertise fine and fail only when a user actually asked for it. That matters here specifically because the model set moves with every InVEST upgrade, which this project does periodically (3.8.0 → 3.14.3 in #31).

## What's added

A module-scoped fixture describes all 25 models once (so the cost is paid a single time), then:

- **`test_describeprocess_succeeds_for_every_model`** — every model renders, with non-empty inputs. A model that raises is captured rather than thrown, so one bad spec reports as a single failure listing every offender instead of aborting on the first.
- **`test_runner_args_hidden_but_results_suffix_exposed`** — measured against the running stack: `workspace_dir` and `n_workers` are exposed by **0/25** processes (the wrapper manages them; they must not be client-settable), `results_suffix` by **25/25**. The second half also keeps `docsrc/models.rst` honest, since that page now tells readers `results_suffix` is accepted.

The `len(described_models) >= 20` guard is deliberate — an empty registry would otherwise satisfy every assertion in the file without describing a single model.

## Verification

Green through the real entry point:

```
$ ./scripts/smoke.sh
...
tests/test_wps_capabilities.py::test_describeprocess_succeeds_for_every_model PASSED [ 66%]
tests/test_wps_capabilities.py::test_runner_args_hidden_but_results_suffix_exposed PASSED [ 77%]
======================== 9 passed, 3 warnings in 36.99s ========================
```

And checked the tests can actually fail — adding `results_suffix` to the hidden set fails exactly this test and no other:

```
FAILED tests/test_wps_capabilities.py::test_runner_args_hidden_but_results_suffix_exposed
1 failed, 4 passed
```

Adds roughly a second to the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG