### PR TITLE
Pin the docs toolchain so the committed HTML stays reproducible

### DIFF
--- a/docsrc/requirements.txt
+++ b/docsrc/requirements.txt
@@ -2,5 +2,13 @@
 # Build with the host InVEST env so MODEL_SPEC resolves live, e.g.:
 #   ~/.local/bin/micromamba run -p ~/esws-invest \
 #       sh -c "pip install -r docsrc/requirements.txt && make -C docsrc html"
-sphinx
-sphinxcontrib-mermaid
+#
+# Pinned on purpose. ../docs is committed and served by Pages, so the build has
+# to be reproducible: an unpinned sphinx turns the command above into an upgrade
+# that rewrites every page and all of _static (the 9.x bump already did this
+# once). alabaster is pinned too -- it is what actually emits the HTML, so it
+# moves the output as much as sphinx does. Bump these deliberately, then rebuild
+# and commit the resulting docs/ churn as its own change.
+sphinx==9.0.4
+sphinxcontrib-mermaid==2.0.2
+alabaster==1.0.0


### PR DESCRIPTION
Follow-through on #33, which made the docs build reproducible with `-E -a`. Unpinned dependencies undo that from the other side.

`docsrc/requirements.txt` documents this in its own header:

```
#   ~/.local/bin/micromamba run -p ~/esws-invest \
#       sh -c "pip install -r docsrc/requirements.txt && make -C docsrc html"
```

With `sphinx` unpinned, that command upgrades Sphinx in place and the very next build rewrites every page and all of `_static`. That already happened once — most of the diff in 2b781ba was static-asset churn from the 9.x bump, not content. Since `docs/` is committed and served by Pages, that churn lands in git and on the live site as a side effect of running the documented build command.

Pinned to the versions that produced the committed output:

- `sphinx==9.0.4`
- `sphinxcontrib-mermaid==2.0.2`
- `alabaster==1.0.0` — included because the theme is what actually emits the HTML, so it moves the output as much as Sphinx does

Bumping any of them is now a deliberate act: change the pin, rebuild, and commit the resulting `docs/` churn as its own change rather than having it ride along with a content edit.

**Verified:** `pip install --dry-run -r docsrc/requirements.txt` resolves with every requirement already satisfied, and a rebuild afterwards leaves `docs/` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG