### PR TITLE
Make the bare-metal install work again instead of re-pinning a fossil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # ESWS containerized stack — common operations.
-.PHONY: build up down logs smoke test
+.PHONY: build up down logs smoke test check-baremetal
 
 build:        ## Build the app + dashboard images
 	docker compose build
@@ -15,5 +15,8 @@ logs:         ## Follow logs from all services
 
 smoke:        ## Build, start the stack, run the pytest smoke suite, tear down
 	./scripts/smoke.sh
+
+check-baremetal:  ## Verify install.sh / requirements_py3.txt still install on a clean machine
+	docker build -f docker/Dockerfile.baremetal-check -t esws/baremetal-check .
 
 test: smoke

--- a/docker/Dockerfile.baremetal-check
+++ b/docker/Dockerfile.baremetal-check
@@ -1,0 +1,61 @@
+# Verification aid — NOT part of the running stack.
+#
+# The bare-metal install path (install.sh + requirements_py3.txt) has no other
+# test, which is how its pins drifted to InVEST 3.8.0 / Django 2.2 / GDAL 2.4.4
+# and stopped being installable at all. This image simulates a clean machine and
+# runs the same commands install.sh options 2 and 4 run, then asserts the
+# resulting environment is the one the code actually needs.
+#
+#   make check-baremetal
+#
+# Slow (it builds InVEST from sdist), so it is not part of `make smoke`.
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl bzip2 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m esws
+USER esws
+WORKDIR /home/esws/esws
+
+COPY --chown=esws:esws requirements_py3.txt ./requirements_py3.txt
+COPY --chown=esws:esws requirements ./requirements
+COPY --chown=esws:esws tools/wpsclient/requirements_py3.txt ./tools/wpsclient/requirements_py3.txt
+
+# --- install.sh option 2: geo stack from conda-forge -------------------------
+RUN mkdir -p "$HOME/.local/bin" && \
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest \
+        | tar -xj -C "$HOME/.local" bin/micromamba
+
+RUN "$HOME/.local/bin/micromamba" create -y -p "$HOME/esws-invest" -c conda-forge \
+        python=3.11 \
+        "gdal=3.10.*" \
+        "pygeoprocessing>=2.4.10" \
+        c-compiler cxx-compiler cython numpy \
+        setuptools setuptools_scm wheel pip babel
+
+# --- install.sh option 4: python stack --------------------------------------
+RUN "$HOME/.local/bin/micromamba" run -p "$HOME/esws-invest" \
+        pip install --no-build-isolation -r requirements_py3.txt
+
+# --- assert the installed stack is the one the code needs -------------------
+RUN "$HOME/.local/bin/micromamba" run -p "$HOME/esws-invest" python -c "\
+import natcap.invest, django, pywps, owslib, svgwrite, flask, bs4, geoserver.catalog; \
+from osgeo import gdal; \
+from natcap.invest import models; \
+print('invest', natcap.invest.__version__); \
+print('gdal', gdal.__version__); \
+print('django', django.get_version()); \
+print('models', len(models.model_id_to_pyname)); \
+assert natcap.invest.__version__ == '3.20.0', natcap.invest.__version__; \
+assert django.get_version().startswith('4.2'), django.get_version(); \
+assert gdal.__version__.startswith('3.10'), gdal.__version__; \
+assert len(models.model_id_to_pyname) == 26, len(models.model_id_to_pyname); \
+assert 'lulc_bas_path' in [i.id for i in models.model_id_to_spec['carbon'].inputs]; \
+print('BARE-METAL INSTALL OK')"
+
+# --- the dashboard-only subset must resolve against it too -------------------
+RUN "$HOME/.local/bin/micromamba" run -p "$HOME/esws-invest" \
+        pip install --dry-run -r tools/wpsclient/requirements_py3.txt \
+    && echo "DASHBOARD SUBSET OK"

--- a/esws-dashboard.service
+++ b/esws-dashboard.service
@@ -4,7 +4,9 @@ After=multi-user.target
 
 [Service]
 Type=idle
-ExecStart=/usr/bin/python3 /home/esws/esws/tools/wpsclient/manage.py runserver 0.0.0.0:8000
+; The Python stack lives in the conda-forge env created by install.sh option 2
+; (ESWS_ENV, /home/esws/esws-invest by default), not in the system interpreter.
+ExecStart=/home/esws/esws-invest/bin/python /home/esws/esws/tools/wpsclient/manage.py runserver 0.0.0.0:8000
 
 [Install]
 WantedBy=multi-user.target

--- a/esws-file-server.service
+++ b/esws-file-server.service
@@ -4,7 +4,9 @@ After=multi-user.target
 
 [Service]
 Type=idle
-ExecStart=/usr/bin/python3 /home/esws/esws/tools/http_server.py
+; The Python stack lives in the conda-forge env created by install.sh option 2
+; (ESWS_ENV, /home/esws/esws-invest by default), not in the system interpreter.
+ExecStart=/home/esws/esws-invest/bin/python /home/esws/esws/tools/http_server.py
 
 [Install]
 WantedBy=multi-user.target

--- a/esws-wps-invest.service
+++ b/esws-wps-invest.service
@@ -4,7 +4,9 @@ After=multi-user.target
 
 [Service]
 Type=idle
-ExecStart=/usr/bin/python3 /home/esws/esws/tools/wpsserver/wpsserver.py
+; The Python stack lives in the conda-forge env created by install.sh option 2
+; (ESWS_ENV, /home/esws/esws-invest by default), not in the system interpreter.
+ExecStart=/home/esws/esws-invest/bin/python /home/esws/esws/tools/wpsserver/wpsserver.py
 
 [Install]
 WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,8 @@ MENU="Choose one of the following options:"
 
 OPTIONS=(0 "Clone ESWS repository"
          1 "Install system requirements"
-         2 "Install GDAL from source with Python 2 and 3 bindings"
-         3 "Install PROJ.4 from source for Shapely Python library"
+         2 "Install geo stack (conda-forge GDAL 3.10)"
+         3 "PROJ.4 (now part of option 2)"
          4 "Install Python requirements"
          5 "Setup OneTjs"
          6 "Setup WPS client"
@@ -51,67 +51,45 @@ read -p "Press [Enter] key to continue..."
 ;;
 
 2)
-sudo pip3 install numpy
-sudo apt-get install sqlite3 libsqlite3-dev
-#install GDAL with Python 3 bindings
-cd ..
-if [[ $LD_LIBRARY_PATH == *"/usr/local/lib"* ]]; then
-    echo "LD_LIBRARY_PATH already set"
-else
-    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-    sudo ldconfig
+# Install the geo stack from conda-forge, mirroring docker/Dockerfile.invest.
+# natcap.invest pins gdal==3.10.*, and pip cannot satisfy that on its own --
+# building GDAL's Python bindings needs a matching libgdal. conda-forge ships
+# libgdal, PROJ and GEOS together, which is why building GDAL and PROJ from
+# source (what this option used to do, at 2.4.4 and 7.0.0) is no longer needed.
+ESWS_ENV="${ESWS_ENV:-$HOME/esws-invest}"
+if [ ! -x "$HOME/.local/bin/micromamba" ]; then
+    mkdir -p "$HOME/.local/bin"
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest \
+        | tar -xj -C "$HOME/.local" bin/micromamba
 fi
-if [ -f "gdal-2.4.4.tar.gz" ]; then
-    echo "GDAL already downloaded"
-else
-    wget http://download.osgeo.org/gdal/2.4.4/gdal-2.4.4.tar.gz
-fi
-tar -xvf gdal-2.4.4.tar.gz
-cd gdal-2.4.4
-./configure --with-python --with-sqlite3
-make
-sudo make install
-sudo pip3 install swig/python
-cd ../esws
+"$HOME/.local/bin/micromamba" create -y -p "$ESWS_ENV" -c conda-forge \
+    python=3.11 \
+    "gdal=3.10.*" \
+    "pygeoprocessing>=2.4.10" \
+    c-compiler cxx-compiler cython numpy \
+    setuptools setuptools_scm wheel pip babel
+echo "Geo stack installed in $ESWS_ENV"
 read -p "Press [Enter] key to continue..."
 ;;
 
 3)
-#install PROJ.4 for shapely
-cd ..
-if [ -f "proj-7.0.0.tar.gz" ]; then
-    echo "PROJ.4 already downloaded"
-else
-    wget http://download.osgeo.org/proj/proj-7.0.0.tar.gz
-fi
-tar -xvf proj-7.0.0.tar.gz
-if [ -f "proj-datumgrid-1.8.zip" ]; then
-    echo "PROJ.4 datum grid already downloaded"
-else
-    wget http://download.osgeo.org/proj/proj-datumgrid-1.8.zip
-fi
-unzip proj-datumgrid-1.8.zip -d proj-7.0.0/nad
-cd proj-7.0.0
-./configure
-make
-sudo make install
-cd ../esws
+# PROJ.4 used to be built from source here for Shapely. conda-forge ships it
+# with the geo stack, so there is nothing left to do.
+echo "PROJ is provided by the conda-forge geo stack -- use option 2 instead."
 read -p "Press [Enter] key to continue..."
 ;;
 
 4)
-#install Python requirements
-#sudo pip3 install --upgrade pip
-
-#sudo pip3 install --upgrade Cython
-#sudo pip3 install --upgrade numpy>=1.11.0
-#sudo pip3 install --upgrade flask
-#sudo pip3 install --upgrade pywps
-#sudo pip3 install --upgrade -e git+https://github.com/boundlessgeo/gsconfig.git@d05a4dc152aa3fb97171f418d7dc09f5f45445a5#egg=gsconfig-py
-#sudo pip3 install --upgrade -r requirements_py2.txt
-#sudo pip3 install --upgrade -r requirements_py3.txt
-
-sudo xargs pip3 install --upgrade < requirements_py3.txt
+# Install the Python stack into the environment from option 2.
+#
+# --no-build-isolation is required: natcap.invest publishes no Linux wheels, so
+# it builds from sdist, and in an isolated build environment its pygeoprocessing
+# build requirement pulls the newest GDAL bindings off PyPI -- which then refuse
+# to build against the conda libgdal ("Python bindings of GDAL 3.13.2 require at
+# least libgdal 3.13.2, but 3.10.3 was found").
+ESWS_ENV="${ESWS_ENV:-$HOME/esws-invest}"
+"$HOME/.local/bin/micromamba" run -p "$ESWS_ENV" \
+    pip install --no-build-isolation -r requirements_py3.txt
 
 read -p "Press [Enter] key to continue..."
 ;;

--- a/requirements.system
+++ b/requirements.system
@@ -20,3 +20,4 @@ python3-pygraphviz
 python3-venv
 libtiff-dev
 libcurl4-openssl-dev
+bzip2

--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -1,32 +1,23 @@
-pip
-GDAL==2.4.4
-Cython
-Pyro4==4.77
-pandas>=0.22.0
-numpy>=1.11.0,!=1.16.0
-Rtree>=0.8.2,!=0.9.1
-scipy>=0.16.1
-Shapely>=1.6.4,<1.7.0
-six
-pygeoprocessing>=1.9.2
-taskgraph[niced_processes]>=0.8.2
-psutil>=5.6.6
-chardet>=3.0.4
-matplotlib
-xlrd>=1.2.0
-xlwt
-natcap.invest==3.8.0
-virtualenv
--e git+https://github.com/mlacayoemery/django-SplitJSONWidget-form.git@77c458d3fd17a97d8bb4753baaed71b3a6f1028c#egg=django-split-json-widget
-django==2.2.28
-django-extensions
-jsonfield
-bs4
-pyparsing
-pydot
-flask
-pywps
-gisdata==0.5.4
-requests>=2.14.0
--e git+https://github.com/boundlessgeo/gsconfig.git@d05a4dc152aa3fb97171f418d7dc09f5f45445a5#egg=gsconfig-py
+# Python requirements for the bare-metal (non-container) install; see install.sh.
+#
+# The application stack is defined once, in requirements/server.txt, which the
+# container image installs too. This file used to be a second, independent copy
+# of it -- which is exactly how it drifted to InVEST 3.8.0 / Django 2.2 / GDAL
+# 2.4.4 while the code moved on to InVEST 3.20 / Django 4.2, leaving pins that
+# could not install at all (GDAL 2.4.4 is source-only and needs libgdal 2.x;
+# natcap.invest 3.8.0 ships only a cp37 wheel). Deferring instead of copying
+# makes that drift impossible.
+#
+# GDAL is deliberately not listed, here or in requirements/server.txt:
+# natcap.invest pins gdal==3.10.*, and pip cannot satisfy that without a
+# matching libgdal already present. Install the geo stack from conda-forge
+# first (install.sh option 2), then install this file into that environment.
+#
+# InVEST also has to be built with --no-build-isolation -- it publishes no Linux
+# wheels, and in an isolated build environment its pygeoprocessing build
+# requirement pulls the newest GDAL bindings off PyPI, which then refuse to
+# build against an older libgdal. install.sh option 4 does this.
+-r requirements/server.txt
+
+# Not part of the services: used only by the docs helper docsrc/svg_invest.py.
 svgwrite

--- a/tools/wpsclient/requirements_py3.txt
+++ b/tools/wpsclient/requirements_py3.txt
@@ -1,4 +1,9 @@
-django==2.2.28
-jsonfield
--e git+https://github.com/mlacayoemery/django-SplitJSONWidget-form.git#egg=django-split-json-widget
+# Dashboard-only subset, for installing the Django WPS client on its own.
+# The full stack (which already includes these) is ../../requirements/server.txt.
+#
+# Dropped when the dashboard was ported to Django 4.2: neither is imported
+# anywhere under tools/wpsclient any more.
+#   jsonfield                    -> django.db.models.JSONField
+#   django-SplitJSONWidget-form  -> tools/wpsclient/wpsclient/widgets.py
+Django==4.2.*
 owslib


### PR DESCRIPTION
Closes the root cause behind #29, #30, #36 and #37.

## Why those PRs kept coming back

Dependabot treated `requirements_py3.txt` as a live requirements file. It wasn't — it was a second, independent copy of the application stack, frozen around the pre-container era while the code moved on:

```
GDAL==2.4.4          natcap.invest==3.8.0      Shapely>=1.6.4,<1.7.0
django==2.2.28       jsonfield                 -e git+...SplitJSONWidget...
```

It could not install on any current system. GDAL 2.4.4 is **source-only** on PyPI and needs libgdal 2.x headers; natcap.invest 3.8.0 ships only a **cp37** wheel while the stack runs Python 3.11. So bumping one line inside it — which is all #36 and #37 did — made it *less* internally consistent without making it usable. #36 would have recorded GDAL 3.13.1, the exact version that broke the InVEST 3.20.0 build in #40.

## The fix

**`requirements_py3.txt` defers instead of copying.** It's now `-r requirements/server.txt` plus `svgwrite` (the only dependency server.txt lacks — `docsrc/svg_invest.py` uses it). Two copies of one stack is what allowed the drift; there is now one source of truth, and dependabot will track the real pins.

**The dashboard subset drops dead entries.** `jsonfield` and the `django-SplitJSONWidget-form` git pin are not imported anywhere under `tools/wpsclient` — #31 replaced them with `django.db.models.JSONField` and a local shim in `wpsclient/widgets.py`.

**`install.sh` had to change too**, or the requirements still couldn't be honest: options 2 and 3 built GDAL 2.4.4 and PROJ 7.0.0 from source, and option 4 pip-installed globally via `sudo xargs`. They now create the same conda-forge geo stack the container uses (`gdal=3.10.*`, which `natcap.invest==3.20.0` pins) and install into it with `--no-build-isolation`, which InVEST requires on Linux.

**The systemd units followed.** All three ran `/usr/bin/python3`, which no longer has the stack; they now point at the env. `esws-tjs.service` already used this pattern.

## Verified, not assumed

This path had **no test at all**, which is how it rotted unnoticed. `docker/Dockerfile.baremetal-check` simulates a clean Ubuntu 24.04 box, runs exactly what install.sh options 2 and 4 run, and asserts the result:

```
$ make check-baremetal
invest 3.20.0
gdal 3.10.3
django 4.2.30
models 26
BARE-METAL INSTALL OK
DASHBOARD SUBSET OK
```

It also asserts carbon exposes the renamed `lulc_bas_path`, so the check fails if the pins and the InVEST version fall out of step again. It builds InVEST from sdist so it's slow — deliberately kept out of `make smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG