### PR TITLE
Move the bare-metal check to Ubuntu 26.04 LTS (Alpine is not compatible)

### DIFF
--- a/docker/Dockerfile.baremetal-check
+++ b/docker/Dockerfile.baremetal-check
@@ -9,7 +9,13 @@
 #   make check-baremetal
 #
 # Slow (it builds InVEST from sdist), so it is not part of `make smoke`.
-FROM ubuntu:24.04
+#
+# The base has to be glibc. Alpine does not work, for three independent reasons:
+# micromamba is a glibc binary and will not execute under musl at all; conda-forge
+# publishes no musl builds, so the geo stack could not be installed even if it
+# did; and Alpine's own GDAL is 3.13.x, while natcap.invest pins gdal==3.10.* --
+# 3.13 is the exact series whose bindings refuse to build against libgdal 3.10.
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl bzip2 ca-certificates \


### PR DESCRIPTION
Bumps `docker/Dockerfile.baremetal-check` from `ubuntu:24.04` to `ubuntu:26.04` LTS, and records in the file why Alpine — the preferred option — cannot be used.

## Alpine doesn't work, and it fails early

Tested rather than reasoned about:

```
$ docker run --rm alpine:latest sh -c 'curl -Ls .../micromamba | tar -xj ...; micromamba --version'
sh: /opt/mm/bin/micromamba: not found
```

That `not found` on a file that exists is the classic musl symptom — the glibc ELF interpreter is missing. micromamba is a glibc binary, so the install path `install.sh` describes cannot even begin on Alpine.

Two further blockers behind that one:

- **conda-forge publishes no musl builds.** Even if micromamba ran, `micromamba create -c conda-forge ... gdal=3.10.*` would install glibc-linked packages that can't execute.
- **Alpine's own GDAL is 3.13.2** (Alpine 3.24.1), but `natcap.invest==3.20.0` pins `gdal==3.10.*`. That's the same 3.13-series mismatch that broke the build in #40: *"Python bindings of GDAL 3.13.2 require at least libgdal 3.13.2, but 3.10.3 was found."* Alpine also ships Python 3.14, ahead of InVEST's cp310–cp312 wheels.

Switching the geo stack to Alpine's `apk` packages would dodge musl but would defeat the point of the check — it exists to verify what `install.sh` actually does, and `install.sh` uses conda-forge because that's where the pinned GDAL 3.10 comes from.

## So: newest compatible base

`ubuntu:26.04` LTS — glibc 2.43, against 2.39 on 24.04. Checked alternatives: `ubuntu:25.10` (glibc 2.42, non-LTS) and `debian:13-slim` (glibc 2.41). 26.04 is both newest and LTS, which suits a check that should keep working untouched.

Base size is noise here anyway — the image is dominated by the conda env and the InVEST build, not the base layer.

## Verified

```
$ make check-baremetal
invest 3.20.0 · gdal 3.10.3 · django 4.2.30 · models 26
BARE-METAL INSTALL OK
DASHBOARD SUBSET OK

$ docker run --rm esws/baremetal-check sh -c '. /etc/os-release; echo $PRETTY_NAME'
Ubuntu 26.04 LTS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG