### PR TITLE
Say why the GeoServer WPS extension is not installed

### DIFF
--- a/scripts/install-geoserver.sh
+++ b/scripts/install-geoserver.sh
@@ -13,6 +13,14 @@
 #
 # GeoServer 3.0 requires Java 17 (see RUNNING.html in the distribution).
 #
+# The GeoServer WPS extension is deliberately not installed. The old 2.17 step
+# added it, but nothing in the stack calls GeoServer's WPS -- ESWS serves WPS
+# itself from pywps (tools/wpsserver), and GeoServer is used only as the OGC
+# endpoint that model outputs are published to. The container does not install
+# it either, so installing it here would put bare metal ahead of what is
+# actually tested. Add it back with GeoServer's own extension install if a
+# deployment needs it.
+#
 # Env overrides: GS_VERSION, GEOSERVER_HOME, GEOSERVER_DATA_DIR
 set -euo pipefail
 


### PR DESCRIPTION
Follow-up to #43. The old 2.17 step installed GeoServer's WPS extension; the 3.0.0 rewrite dropped it without comment, which reads as an oversight rather than a decision.

It was deliberate. Nothing in the stack calls GeoServer's WPS — ESWS serves WPS itself from pywps (`tools/wpsserver`), and GeoServer is only the OGC endpoint that model outputs get published to. The single reference, `tools/wpsclient/wpsclient/owslib_test.py`, is an unreferenced scratch script that pytest doesn't collect (`testpaths = tests`, and the filename doesn't match `test_*.py`).

The container doesn't install the extension either, so adding it on bare metal would put that path ahead of what's actually tested — the opposite of the version-matching #43 was for.

Comment-only change to `scripts/install-geoserver.sh`; `bash -n` passes. Deliberately not re-running `make check-geoserver` for a comment — it downloads a 126MB distribution and boots it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG