### PR TITLE
Fix the dashboard's WPS views, which nothing had ever reached

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,7 @@
 """Django dashboard smoke tests — key views return 200 on Django 4.2."""
+import re
+
+import pytest
 import requests
 
 
@@ -15,3 +18,54 @@ def test_dashboard_server_list(dashboard_url):
 def test_dashboard_job_list(dashboard_url):
     r = requests.get(dashboard_url + "/job/", timeout=30)
     assert r.status_code == 200, r.text[:500]
+
+
+@pytest.fixture(scope="module")
+def registered_wps_server(dashboard_url, wps_url):
+    """A WPS server registered in the dashboard, returning its primary key.
+
+    Everything below needs one: with no servers the list template never enters
+    its row loop and the element views are unreachable, which is how both the
+    missing ``server_wps_capabilities`` URL name and the owslib ``verbose``
+    kwarg survived the Django 4.2 port unnoticed.
+
+    Depends on wps_url so the WPS is actually answering first -- the dashboard
+    calls GetCapabilities server-side to list processes, and the WPS takes some
+    seconds to import all 26 InVEST models on start.
+    """
+    r = requests.get(
+        "%s/server/WPS/register/Smoke WPS/url/%s" % (dashboard_url, wps_url),
+        timeout=60)
+    assert r.status_code == 200, r.text[:500]
+
+    listing = requests.get(dashboard_url + "/server/WPS/", timeout=30)
+    assert listing.status_code == 200, listing.text[:1000]
+    pks = re.findall(r"/server/WPS/(\d+)/", listing.text)
+    assert pks, listing.text[:1000]
+    return max(int(p) for p in pks)
+
+
+def test_dashboard_server_list_renders_a_registered_server(registered_wps_server,
+                                                           dashboard_url, wps_url):
+    """The row template must reverse every URL name it references."""
+    r = requests.get(dashboard_url + "/server/WPS/", timeout=30)
+    assert r.status_code == 200, r.text[:1000]
+    assert wps_url in r.text
+
+
+def test_dashboard_lists_wps_processes(registered_wps_server, dashboard_url):
+    r = requests.get("%s/server/WPS/%d/element/" % (dashboard_url, registered_wps_server),
+                     timeout=120)
+    assert r.status_code == 200, r.text[:1000]
+    assert "annual_water_yield" in r.text, r.text[:1000]
+
+
+def test_dashboard_wps_process_detail(registered_wps_server, dashboard_url):
+    """Describes a process through owslib -- the path that raised
+    TypeError: WebProcessingService.__init__() got an unexpected keyword
+    argument 'verbose' once owslib dropped that parameter."""
+    r = requests.get(
+        "%s/server/WPS/%d/element/annual_water_yield/" % (dashboard_url,
+                                                          registered_wps_server),
+        timeout=120)
+    assert r.status_code == 200, r.text[:1000]

--- a/tools/wpsclient/utilities/describe_process.py
+++ b/tools/wpsclient/utilities/describe_process.py
@@ -3,7 +3,7 @@ import owslib.wps
 server_url = "http://127.0.0.1:5000/wps" #PyWPS
 process_id = "routedem"
 
-wps = owslib.wps.WebProcessingService(server_url, verbose=False, skip_caps=True)
+wps = owslib.wps.WebProcessingService(server_url, skip_caps=True)
 process = wps.describeprocess(process_id)
 
 process_input = []

--- a/tools/wpsclient/wpsclient/owslib_test.py
+++ b/tools/wpsclient/wpsclient/owslib_test.py
@@ -15,7 +15,7 @@ describe_processes = ["JTS:area"]
 test_processid = "geo:centroid"
 
 wps_url = geoserver + "/geoserver/ows"
-wps = owslib.wps.WebProcessingService(wps_url, verbose=False, skip_caps=True)
+wps = owslib.wps.WebProcessingService(wps_url, skip_caps=True)
 
 
 if list_capabilities:
@@ -93,8 +93,7 @@ print ("\nTesting modified XML request for process %s" % processid)
 execution = owslib.wps.WPSExecution(version="1.0.0",
                                     url= geoserver + "/geoserver/ows",
                                     username=None,
-                                    password=None,
-                                    verbose=False)
+                                    password=None)
 
 requestElement = execution.buildRequest(processid,
                                         inputs)#,

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_list.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_list.html
@@ -17,7 +17,7 @@
 <td></td>
 <td>{{ server.title }}</td>
 <td>{{ server.url}}</td>
-<td><a href="{% url 'server_wps_capabilities' server_type=server.server_type server_pk=server.pk %}">List</a></td>
+<td><a href="{% url 'server_element_list' server_type=server.server_type server_pk=server.pk %}">List</a></td>
 <td><a href="{% url 'server_job_list' server_pk=server.pk%}">Instances</a></td>
 </tr>
 {% endfor %}

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -387,7 +387,7 @@ def server_wps_element_detail(request, server_pk, element_id):
     link = server.url + "?service=wps&version=1.0.0&request=DescribeProcess&IDENTIFIER=" + element_id
     description = parseString(requests.get(link).text).toprettyxml()
 
-    wps = owslib.wps.WebProcessingService(server.url, verbose=False, skip_caps=True)
+    wps = owslib.wps.WebProcessingService(server.url, skip_caps=True)
     process = wps.describeprocess(element_id)
 
     process_input = []
@@ -486,7 +486,7 @@ def job_detail(request, job_pk):
 def get_wps_input_fields(server_pk, process_id):
     server = get_object_or_404(ServerWPS, pk=server_pk)
 
-    wps = owslib.wps.WebProcessingService(server.url, verbose=False, skip_caps=True)
+    wps = owslib.wps.WebProcessingService(server.url, skip_caps=True)
     process = wps.describeprocess(process_id)
 
     process_input = []
@@ -583,7 +583,7 @@ def job_new(request, server_pk, process_id):
 
     args = collections.OrderedDict()
 
-    wps = owslib.wps.WebProcessingService(server.url, verbose=False, skip_caps=True)
+    wps = owslib.wps.WebProcessingService(server.url, skip_caps=True)
     process = wps.describeprocess(process_id)
 
     for parameter in process.dataInputs:            


### PR DESCRIPTION
Clicking a process id in the dashboard raised:

```
TypeError: WebProcessingService.__init__() got an unexpected keyword argument 'verbose'
  views.py:390, in server_wps_element_detail
```

## Two bugs, both invisible until a server exists

**owslib dropped `verbose`.** 0.35.0 takes `url, version, username, password, skip_caps, headers, verify, cert, timeout, auth, language`. `views.py` passed `verbose=False` in **three** places — the element detail plus both job-execution paths — so process detail *and* running a job were broken. Removed from two utility scripts calling the same API as well.

**The server list was broken for longer.** `server_list.html:20` reverses `server_wps_capabilities`, a URL name that has **never existed** in `urls.py` — the template has referenced it since 2019 (`2265917`). It sits unconditionally inside the row loop, so `/server/CSV|WCS|WFS|WPS/` all returned **500** the moment any server was registered. Now points at `server_element_list`, the route that actually lists a server's contents.

Neither is a regression from the Django 4.2 port (#31). Both were simply unreachable: nothing registers a server by default, and with an empty list the template never enters its loop and the element views have no server to hang off. The smoke suite passed while every WPS page in the dashboard was broken.

## Closing that gap

The dashboard tests now register a WPS server and walk the path a user actually takes — server list → process list → process detail. All three would have caught these.

The fixture depends on `wps_url` so the WPS is answering before the dashboard calls GetCapabilities server-side. Without that ordering the element views raise `ConnectionError` while InVEST is still importing its 26 models — I hit exactly that on the first run.

## Verification

```
$ make smoke
12 passed
```

Against a running stack, `/server/WPS/4/element/annual_water_yield/` now renders the model's inputs:

> Id `annual_water_yield` · Title Annual Water Yield · Abstract InVEST Annual Water Yield model.
> Inputs: `results_suffix`, `lulc_path`, `depth_to_root_rest_layer_path`, …

Note this fixes the *views*. The dashboard still has no endpoints on a fresh start — that's the seeding work I scoped separately, and this PR is its prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG