### PR TITLE
Teach the process detail page about template sources

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -127,6 +127,24 @@ def test_template_lists_the_same_processes(registered_template, dashboard_url):
     assert "annual_water_yield" in r.text
 
 
+def test_template_process_detail_and_its_new_job_link(registered_template,
+                                                      dashboard_url):
+    """Walk the click-through: template -> process -> new job.
+
+    Every per-type dispatch table in views has to know about TPL. The process
+    detail page was missed and raised KeyError, so this covers the whole path
+    rather than just the list and the form.
+    """
+    detail = requests.get("%s/server/TPL/%d/element/annual_water_yield/"
+                          % (dashboard_url, registered_template), timeout=120)
+    assert detail.status_code == 200, detail.text[:1000]
+
+    # The "new job" link must carry the template's pk, or the form it opens
+    # would be the unprefilled one.
+    assert 'href="/server/%d/execute/annual_water_yield/"' % registered_template \
+        in detail.text, detail.text[:2000]
+
+
 def test_template_form_is_prefilled_from_the_sample_datastack(registered_template,
                                                               registered_wps_server,
                                                               dashboard_url):

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -372,10 +372,10 @@ def server_element_detail(request, server_type, server_pk, element_id):
         "CSV" : server_csv_element_detail,        
         "WCS" : server_wcs_element_detail,
         "WFS" : server_wfs_element_detail,
-        "WPS" : server_wps_element_detail
+        "WPS" : server_wps_element_detail,
+        # A template describes its processes exactly like the WPS it points at.
+        "TPL" : server_wps_element_detail
         }
-
-    print(server_type)
 
     return server_dict[server_type](request, server_pk, element_id)
 


### PR DESCRIPTION
`/server/TPL/5/element/annual_water_yield/` raised `KeyError: 'TPL'`.

`server_element_detail` dispatches per server type, and it was the one table not extended when the Templates source was added:

```python
server_dict = {
    "CSV": server_csv_element_detail,
    "WCS": server_wcs_element_detail,
    "WFS": server_wfs_element_detail,
    "WPS": server_wps_element_detail,   # no TPL
}
```

So the click-through the feature exists for — template → process → **new job** — broke on the middle step. Templates describe their processes exactly like the WPS they point at, so it now dispatches to the same handler; `get_object_or_404(ServerWPS, ...)` already accepts a template because `ServerTemplate` subclasses it.

The new test walks the whole path and asserts the "new job" link carries the **template's** pk — with the WPS pk it would open the unprefilled form, which a plain "page loads" check would have passed. My earlier template tests covered the process list and the form but not the page between them, which is how this got through.

Also drops a stray `print(server_type)` debug line.

**Verified:** `make smoke` 18 passed; `/server/TPL/5/element/<process>/` and the WPS equivalent both 200; the link resolves to `/server/5/execute/annual_water_yield/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG