### PR TITLE
Fix asynchronous execution, then declare each model's real outputs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       GEOSERVER_USER: ${GEOSERVER_USER:-admin}
       GEOSERVER_PASS: ${GEOSERVER_PASS:-geoserver}
       WPS_WORKSPACE_PREFIX: esws-
+      # statusLocation and asReference URLs are handed to clients, so they must
+      # use the host mapping rather than the container port.
+      WPS_OUTPUT_URL: http://localhost:${WPS_HOST_PORT:-5000}/outputs
     depends_on:
       - geoserver
 

--- a/docker/Dockerfile.invest
+++ b/docker/Dockerfile.invest
@@ -42,6 +42,16 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN pip install --no-cache-dir --no-build-isolation natcap.invest==3.20.0 && \
     pip install --no-cache-dir -r /tmp/server.txt
 
+# pywps writes stored ExecuteResponse documents and referenced outputs here
+# (outputpath in tools/wpsserver/pywps.cfg). Create it as the image user so the
+# named volume compose mounts over it inherits that ownership: Docker seeds an
+# empty volume from the image directory it covers. Without this the volume comes
+# out root-owned, the container runs as mambauser, and every asynchronous
+# request fails with "Writing Response Document failed with : [Errno 13]
+# Permission denied" -- so storeExecuteResponse and asReference are advertised
+# but unusable.
+RUN mkdir -p /tmp/wpsoutputs
+
 # Application code (compose also bind-mounts ./ over /app for live editing).
 COPY --chown=$MAMBA_USER:$MAMBA_USER . /app
 WORKDIR /app

--- a/tests/test_wps_capabilities.py
+++ b/tests/test_wps_capabilities.py
@@ -5,6 +5,8 @@ importable InVEST model, DescribeProcess should render every one of those specs
 (and expose the expected args for a known model), the runner-only arguments
 should stay hidden, and the echo process should round-trip.
 """
+import re
+
 import pytest
 import requests
 from owslib.wps import WebProcessingService
@@ -100,6 +102,61 @@ def test_describeprocess_carbon_exposes_spec_args(wps_url):
     assert "lulc_bas_path" in input_ids
     assert "carbon_pools_path" in input_ids
     assert "calc_sequestration" in input_ids
+
+
+def test_processes_declare_their_real_outputs(wps_url):
+    """Every model must advertise the outputs it produces, not one blob.
+
+    Each declared output is a ComplexOutput derived from MODEL_SPEC.outputs, so
+    a client can see what it will get and request individual outputs by
+    reference. `response` is retained alongside them for existing clients.
+    """
+    wps = WebProcessingService(wps_url, version="1.0.0")
+    carbon = wps.describeprocess("carbon")
+    identifiers = {o.identifier for o in carbon.processOutputs}
+
+    assert "response" in identifiers, identifiers
+    assert len(identifiers) > 5, identifiers
+    # a raster the model always produces
+    assert "c_storage_bas" in identifiers, sorted(identifiers)
+
+
+def test_executing_returns_fetchable_output_references(wps_url):
+    """A run's outputs come back as URLs that actually serve the file.
+
+    Exercises the whole chain that was broken: pywps needs a writable
+    outputpath, wpsserver has to serve it, and outputurl has to be reachable
+    from outside the container.
+    """
+    resp = requests.get(wps_url, params={
+        "service": "WPS",
+        "version": "1.0.0",
+        "request": "Execute",
+        "identifier": "carbon",
+        "DataInputs": ";".join([
+            "lulc_bas_path=/data/invest/Carbon/lulc_current_willamette.tif",
+            "carbon_pools_path=/data/invest/Carbon/carbon_pools_willamette.csv",
+            "calc_sequestration=false",
+        ]),
+    }, timeout=900)
+    assert resp.status_code == 200, resp.text[:1000]
+    assert "ProcessSucceeded" in resp.text, resp.text[:3000]
+
+    hrefs = [h for h in re.findall(r'href="([^"]+)"', resp.text) if h]
+    assert hrefs, resp.text[:3000]
+
+    # The advertised URL is the one external clients use (WPS_OUTPUT_URL, the
+    # host mapping). These tests run on the compose network, so point it back at
+    # the service instead of the published port.
+    from urllib.parse import urlsplit, urlunsplit
+    wps_parts = urlsplit(wps_url)
+    href_parts = urlsplit(hrefs[0])
+    internal = urlunsplit((wps_parts.scheme, wps_parts.netloc,
+                           href_parts.path, href_parts.query, ""))
+
+    fetched = requests.get(internal, timeout=120)
+    assert fetched.status_code == 200, internal
+    assert len(fetched.content) > 0, internal
 
 
 def test_echo_execute_roundtrips(wps_url):

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -102,6 +102,124 @@ def _literal_input(inp):
     return pywps.LiteralInput(data_type="string", **kwargs)
 
 
+# MODEL_SPEC output class -> the mime type to advertise for it.
+_OUTPUT_FORMATS = {
+    invest_spec.SingleBandRasterOutput: "image/tiff",
+    invest_spec.RasterOutput: "image/tiff",
+    invest_spec.VectorOutput: "application/zip",   # shapefile + sidecars
+    invest_spec.CSVOutput: "text/csv",
+}
+_DEFAULT_OUTPUT_FORMAT = "application/octet-stream"
+
+
+class _Falsey(dict):
+    """Missing names are False, not an error."""
+
+    def __missing__(self, key):
+        return False
+
+
+def output_is_expected(output, args):
+    """Whether ``output``'s created_if condition holds for ``args``.
+
+    created_if is either a bool or an expression naming other inputs, e.g.
+    "sub_watersheds_path" or "do_valuation and (not price_table)". An input the
+    caller never supplied is falsey -- that is the whole point of the condition,
+    and evaluating it as a NameError would wrongly mark the output as expected.
+    """
+    condition = getattr(output, "created_if", True)
+    if isinstance(condition, bool):
+        return condition
+    if args is None:
+        return True
+    env = _Falsey((key, bool(value)) for key, value in args.items())
+    try:
+        return bool(eval(condition, {"__builtins__": {}}, env))  # noqa: S307
+    except Exception:  # noqa: BLE001 - an unparseable condition is not fatal
+        logger.debug("Could not evaluate created_if %r; assuming produced",
+                     condition)
+        return True
+
+
+def anticipated_outputs(spec, args=None):
+    """The file outputs a run with ``args`` is expected to produce.
+
+    With args omitted this is every file output the model declares, which is
+    what DescribeProcess has to advertise -- WPS has no way to say that an
+    output only appears under some conditions.
+    """
+    expected = []
+    for output in spec.outputs:
+        # Only file outputs have a workspace-relative path; numeric and string
+        # outputs are metadata with nothing to fetch or publish.
+        if not getattr(output, "path", None):
+            continue
+        if not output_is_expected(output, args):
+            continue
+        expected.append(output)
+    return expected
+
+
+def _output_identifier(output):
+    """A WPS-safe identifier for a declared output."""
+    ident = output.id or os.path.splitext(os.path.basename(output.path))[0]
+    return re.sub(r"[^0-9A-Za-z_.-]+", "_", str(ident)).strip("_") or "output"
+
+
+def _zip_shapefile(shp_path):
+    """Zip a shapefile and its sidecars; returns the archive path or None."""
+    import zipfile
+
+    stem = os.path.splitext(shp_path)[0]
+    members = [stem + ext for ext in (".shp", ".shx", ".dbf", ".prj", ".cpg",
+                                      ".sbn", ".sbx", ".qix")]
+    members = [m for m in members if os.path.isfile(m)]
+    if not members:
+        return None
+
+    archive = stem + ".zip"
+    try:
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zf:
+            for member in members:
+                zf.write(member, os.path.basename(member))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not zip %s: %s", shp_path, str(exc)[:200])
+        return None
+    return archive
+
+
+def _complex_outputs(spec):
+    """One pywps ComplexOutput per file output the model declares."""
+    outputs, seen = [], set()
+    for output in anticipated_outputs(spec):
+        identifier = _output_identifier(output)
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+
+        mime = _DEFAULT_OUTPUT_FORMAT
+        for cls, fmt in _OUTPUT_FORMATS.items():
+            if isinstance(output, cls):
+                mime = fmt
+                break
+
+        abstract = (output.about or "").strip()
+        # Conditional outputs cannot be expressed in DescribeProcess -- there is
+        # no output-side minOccurs -- so say so in the abstract instead.
+        condition = getattr(output, "created_if", True)
+        if isinstance(condition, str):
+            abstract = ("%s\n\n[invest:created_if=%s]" % (abstract, condition)).strip()
+
+        outputs.append(pywps.ComplexOutput(
+            identifier,
+            output.path,
+            abstract=abstract[:4000],
+            supported_formats=[pywps.Format(mime)],
+            as_reference=True,
+        ))
+    return outputs
+
+
 class InvestProcess(pywps.Process):
     """A pywps Process for one InVEST model, derived from its MODEL_SPEC."""
 
@@ -122,9 +240,14 @@ class InvestProcess(pywps.Process):
                 logger.warning("Could not build input %s for %s: %s",
                                inp.id, model_id, exc)
 
+        # `response` is retained for backward compatibility: it carries the
+        # published WMS URLs and existing clients read it. The per-output
+        # ComplexOutputs are the real declaration -- WPS supports any number of
+        # outputs, and until now every model advertised only this one string.
         outputs = [pywps.LiteralOutput("response",
                                        "Published layers or workspace path",
                                        data_type="string")]
+        outputs.extend(_complex_outputs(spec))
 
         abstract = (module.__doc__ or spec.model_title or model_id or "").strip()
 
@@ -155,19 +278,18 @@ class InvestProcess(pywps.Process):
                 args[arg_id] = value
         return args
 
-    def _build_uploads(self, ws, workspace_dir, spec):
-        """Predict raster/vector outputs from MODEL_SPEC.outputs.
+    def _build_uploads(self, ws, workspace_dir, spec, args=None):
+        """The raster/vector layers this run is expected to publish.
 
-        Returns {"ws:layer": path}. Missing files (outputs whose ``created_if``
-        condition did not hold) are skipped by easyows.Job.run at publish time.
+        Returns {"ws:layer": path}. When ``args`` is given, each output's
+        ``created_if`` condition is evaluated against them, so the result is the
+        set the run should actually produce rather than every output the model
+        could ever emit. Anything still missing on disk afterwards is skipped by
+        easyows.Job.run.
         """
         uploads = {}
-        for output in spec.outputs:
-            # Only file outputs have a workspace-relative path; numeric/string
-            # outputs are metadata and have nothing to publish.
-            filename = getattr(output, "path", None)
-            if not filename:
-                continue
+        for output in anticipated_outputs(spec, args):
+            filename = output.path
             lower = filename.lower()
             is_raster = isinstance(output, (invest_spec.SingleBandRasterOutput,
                                             invest_spec.RasterOutput)) \
@@ -202,7 +324,7 @@ class InvestProcess(pywps.Process):
             raise pywps.exceptions.NoApplicableCode("Could not clean GeoServer workspace(s)")
         ws = cat.make_named_workspace(str(self.uuid))
 
-        uploads = self._build_uploads(ws, args["workspace_dir"], spec)
+        uploads = self._build_uploads(ws, args["workspace_dir"], spec, args)
 
         job = easyows.Job(module.execute, args, uploads,
                           "InVEST %s WPS job %s" % (self.model_id, ws),
@@ -241,7 +363,43 @@ class InvestProcess(pywps.Process):
         response.outputs["response"].data = (
             " ; ".join(layer_urls) if layer_urls else args["workspace_dir"])
         response.outputs["response"].uom = pywps.UOM("unity")
-        logger.info("END InVEST WPS model=%s published=%d", self.model_id, len(published))
+
+        # Populate the declared per-output references for whatever this run
+        # actually produced. DescribeProcess has to advertise every output the
+        # model can emit, since WPS cannot express a conditional output, so the
+        # ones whose created_if did not hold are simply left unset.
+        expected = anticipated_outputs(spec, args)
+        filled = 0
+        for output in expected:
+            identifier = _output_identifier(output)
+            if identifier not in response.outputs:
+                continue
+            path = os.path.join(args["workspace_dir"], output.path)
+
+            # Must be a regular file. Some declared outputs are directories on
+            # disk -- taskgraph_cache/taskgraph.db is declared as a file but
+            # taskgraph creates a directory there -- and attaching one fails
+            # inside pywps at response-construction time with IsADirectoryError,
+            # which aborts the entire ExecuteResponse rather than that output.
+            if not os.path.isfile(path):
+                continue
+
+            if path.lower().endswith(".shp"):
+                # A shapefile is a set of sidecar files; delivering just the
+                # .shp would be useless, so ship the set as the advertised zip.
+                path = _zip_shapefile(path)
+                if path is None:
+                    continue
+
+            try:
+                response.outputs[identifier].file = path
+                filled += 1
+            except Exception as exc:  # noqa: BLE001 - one output must not fail the job
+                logger.warning("Could not attach output %s: %s",
+                               identifier, str(exc)[:200])
+
+        logger.info("END InVEST WPS model=%s anticipated=%d produced=%d published=%d",
+                    self.model_id, len(expected), filled, len(published))
         return response
 
 

--- a/tools/wpsserver/wpsserver.py
+++ b/tools/wpsserver/wpsserver.py
@@ -50,9 +50,29 @@ logging.info("Registered %d WPS processes", len(wps_processes))
 config_file=os.path.join(os.path.dirname(__file__), "pywps.cfg")
 service = pywps.Service(wps_processes, config_file)
 
+# The URL clients are handed for stored documents and referenced outputs. It has
+# to match how they reach this server, not the port inside the container -- same
+# reasoning as GEOSERVER_PUBLIC_URL in docker-compose.yml.
+_output_url = os.environ.get("WPS_OUTPUT_URL")
+if _output_url:
+    pywps.configuration.CONFIG.set("server", "outputurl", _output_url)
+
+_output_path = pywps.configuration.get_config_value("server", "outputpath")
+
 @app.route('/wps', methods=['GET', 'POST'])
 def wps():
     return service
+
+@app.route('/outputs/<path:filename>')
+def outputs(filename):
+    """Serve what pywps stored under outputpath.
+
+    Asynchronous execution (storeExecuteResponse=true) answers immediately with
+    a statusLocation pointing here, and asReference=true returns outputs as URLs
+    under the same path. Without this route both are written to disk and then
+    404 to the client, so the whole asynchronous flow is unusable.
+    """
+    return flask.send_from_directory(_output_path, filename)
 
 bind_host='0.0.0.0'
 app.run(threaded=True,host=bind_host)


### PR DESCRIPTION
Three things, in the order they had to happen.

## Async execution was advertised but broken

Processes declare `storeSupported="true" statusSupported="true"`, yet every async request failed:

```
Writing Response Document failed with :
[Errno 13] Permission denied: '/tmp/wpsoutputs/<uuid>.xml'
```

`outputpath` is a named volume. Docker seeds an empty volume from the image directory it covers — and the image had no such directory, so the volume came out `root`-owned while the container runs as `mambauser`. Creating it in the Dockerfile as the image user makes a fresh volume inherit that ownership. **An existing volume must be removed once** for this to take effect.

That alone wasn't enough: `wpsserver.py` only routed `/wps`, so stored documents were written and then 404'd — `statusLocation` pointed at nothing. Added a route serving `outputpath`, which also makes `asReference` usable since referenced outputs land there too.

And the URL handed out was wrong: `outputurl` was pinned to the container port, so `statusLocation` was unreachable from outside. It now comes from `WPS_OUTPUT_URL`, which compose derives from `WPS_HOST_PORT` — same reasoning as `GEOSERVER_PUBLIC_URL`.

This matters beyond conformance: without it every job blocks its HTTP request for the full run, and `scenic_quality` already takes four minutes.

## (1) Real outputs declared

Each file output in `MODEL_SPEC.outputs` becomes a `ComplexOutput` with a mime type by kind (`image/tiff`, `application/zip`, `text/csv`), `as_reference=True`. carbon goes **1 → 14** declared outputs; annual_water_yield **1 → 29**. `response` is retained alongside, so existing clients — including our own smoke test — are unaffected.

Conditional outputs can't be expressed in DescribeProcess (there's no output-side `minOccurs`), so the declaration is a superset and the condition is published in the abstract as `[invest:created_if=…]`, reusing the trailer convention already used for input types.

## (2) Outputs anticipated before the run

`created_if` is evaluated against the submitted args *before* executing, so the publish set and the outputs to attach are what this run should produce — rather than everything the model could emit, filtered afterwards by `os.path.exists`.

One subtlety: an arg that was never supplied must be **falsey**. The obvious `eval()` raises `NameError` and would wrongly mark the output as expected — which is exactly the mistake I made when first measuring this.

## Two hazards handled

- **Only regular files get attached.** `taskgraph_cache/taskgraph.db` is declared as a file but taskgraph creates a *directory* there. Attaching it fails inside pywps at response-construction time with `IsADirectoryError`, aborting the **entire** ExecuteResponse — and a `try/except` around the assignment doesn't help, because the failure happens later.
- **Shapefiles are zipped with their sidecars**, which is what the advertised `application/zip` promises. A bare `.shp` would be useless to a consumer.

## Verification

```
DescribeProcess carbon   → 14 outputs incl. c_storage_bas
Execute carbon           → ProcessSucceeded, 14 <wps:Reference>
first href               → 200, image/tiff, 912458 bytes
async carbon             → ProcessAccepted → ProcessSucceeded via statusLocation
model sweep              → 24 passed, 0 failed (unchanged)
make smoke               → 20 passed
```

Note the destination/Pending upload feature is **not** in this PR — it still has open design questions (server-declared `AllowedValues` vs dashboard-supplied `anyURI`, and who reconciles Pending → real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG