### PR TITLE
Run jobs asynchronously — and fix the publishing that results_suffix silently broke

### DIFF
--- a/tools/wpsclient/wpsclient/models.py
+++ b/tools/wpsclient/wpsclient/models.py
@@ -103,6 +103,10 @@ class Job(models.Model):
     identifier = models.CharField(max_length=200)
     status = models.CharField(max_length=12, default='Pending')
     status_url = models.TextField(default="")
+    # Where the WPS parks the stored ExecuteResponse for an asynchronous run
+    # (statusLocation). Polled to advance `status`; empty for a job that has
+    # not been submitted yet.
+    status_location = models.TextField(default="")
 
     args = models.JSONField(default=dict)
 

--- a/tools/wpsclient/wpsclient/templates/wpsclient/job_run.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/job_run.html
@@ -11,6 +11,12 @@
         <tr><td>{{k}}</td><td>{{v}}</td></tr>
         {% endfor %}
         </table>
+        <p><b>Status: </b>{{ job.status }}
+        {% if job.status_location %}
+        &mdash; <a href="{% url 'job_status' job_pk=job.pk %}">Refresh</a>
+        (<a href="{{ job.status_location }}">raw</a>)
+        {% endif %}
+        </p>
         <p><b>Job Queue: </b></p>
         <p><a href="{% url 'server_job_list' server_pk=job.server.pk%}">Server</a></p>
         <p><a href="{% url 'job_list' %}">All</a></p>

--- a/tools/wpsclient/wpsclient/urls.py
+++ b/tools/wpsclient/wpsclient/urls.py
@@ -46,5 +46,6 @@ urlpatterns = [
 ##    url(r'^test/(?P<process_pk>[a-zA-Z0-9_:]+)/$', views.job_edit_json, name='job_edit_json'),
 ##    url(r'^test/(?P<server_pk>\d+)/execute/(?P<process_id>[a-zA-Z0-9_:]+)/$', views.job_new_wps, name='job_new_wps'),
     url(r'^test/wy/$', views.water_yield, name='water_yield'),
-    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/run/$', views.job_run, name='job_run'),    
+    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/run/$', views.job_run, name='job_run'),
+    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/status/$', views.job_status, name='job_status'),    
 ]

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -808,11 +808,84 @@ def water_yield(request):
                     process_id="annual_water_yield")
 
 
-def job_to_wps_url(job):
+def job_to_wps_url(job, asynchronous=True):
+    """The WPS Execute URL for a job.
+
+    Asynchronous by default: with storeExecuteResponse the server answers
+    immediately with a statusLocation instead of holding the connection open for
+    the whole run. Some InVEST models take minutes -- scenic_quality is around
+    four -- and a synchronous request means the browser waits that long.
+    """
     url = job.server.url + "?service=wps&version=1.0.0&request=Execute&IDENTIFIER=" + job.identifier + "&datainputs="
     url = url + ";".join(["%s=%s" % (k, quote(quote(job.args[k]))) for k in job.args.keys()])
+    if asynchronous:
+        url += "&storeExecuteResponse=true&status=true&ResponseDocument=response"
 
-    return url    
+    return url
+
+
+# The WPS status values that mean the run is over, one way or the other.
+_JOB_FINISHED = {"Succeeded", "Failed"}
+
+
+def _reachable_via_server(url, server_url):
+    """Rewrite a WPS-issued URL onto the host we reach that server on.
+
+    statusLocation and output references carry the address the WPS advertises to
+    the outside world (WPS_OUTPUT_URL, the published host port). The dashboard is
+    an internal client on the compose network, where that address does not
+    resolve, so the path is re-hosted onto whatever we already use to talk to
+    the server. Otherwise polling fails silently and a job sits on Accepted
+    forever.
+    """
+    from urllib.parse import urlsplit, urlunsplit
+    try:
+        target, source = urlsplit(url), urlsplit(server_url)
+        if not (target.path and source.netloc):
+            return url
+        return urlunsplit((source.scheme or target.scheme, source.netloc,
+                           target.path, target.query, ""))
+    except Exception:  # noqa: BLE001
+        return url
+
+
+def _wps_status(xml):
+    """Read the ProcessX state out of an ExecuteResponse."""
+    match = re.search(r"Process(Accepted|Started|Paused|Succeeded|Failed)", xml)
+    return match.group(1) if match else ""
+
+
+def job_status(request, job_pk):
+    """Poll the job's statusLocation and advance its recorded status.
+
+    Nothing in the dashboard runs in the background, so this is the moment a
+    job's outcome becomes known -- and, once uploads are wired up, where
+    anticipated outputs get reconciled against what was really produced.
+    """
+    job = get_object_or_404(Job, pk=job_pk)
+
+    xml = ""
+    if job.status_location:
+        try:
+            with urllib.request.urlopen(job.status_location, timeout=60) as response:
+                xml = response.read().decode("utf-8", "replace")
+        except Exception as exc:  # noqa: BLE001 - a poll failure is not fatal
+            xml = "<!-- could not read statusLocation: %s -->" % exc
+
+        state = _wps_status(xml)
+        if state:
+            job.status = state
+            job.save()
+
+    if xml.startswith("<?xml") or xml.startswith("<wps"):
+        try:
+            xml = "\n".join(line for line in parseString(xml).toprettyxml().split("\n")
+                            if line.strip())
+        except Exception:  # noqa: BLE001 - show it raw if it will not parse
+            pass
+
+    return render(request, "wpsclient/job_run.html", {"job": job, "xml": xml})
+
 
 def job_run(request, job_pk):
     job = get_object_or_404(Job, pk=job_pk)
@@ -822,22 +895,39 @@ def job_run(request, job_pk):
         job.status_url = job_to_wps_url(job)
         job.save()
 
-        return dashboard(request)    
+        return dashboard(request)
 
     elif job.status == "Run":
-        print(job.status_url)
-        response = urllib.request.urlopen(job.status_url)
-        #response = urllib.request.urlopen("http://127.0.0.1:5000/wps?service=wps&version=1.0.0&request=GetCapabilities")
-
-        xml = parseString(response.read()).toprettyxml()
-        xml = '\n'.join([line for line in xml.split('\n') if line.strip()])
-
-        job.status = "Complete"
+        # Submit and return: the response carries a statusLocation, not results.
         job.status_url = job_to_wps_url(job)
+        try:
+            with urllib.request.urlopen(job.status_url, timeout=120) as response:
+                xml = response.read().decode("utf-8", "replace")
+        except Exception as exc:  # noqa: BLE001
+            job.status = "Failed"
+            job.save()
+            return render(request, "wpsclient/job_run.html",
+                          {"job": job, "xml": "submit failed: %s" % exc})
+
+        location = re.search(r'statusLocation="([^"]+)"', xml)
+        if location:
+            job.status_location = _reachable_via_server(location.group(1),
+                                                        job.server.url)
+        job.status = _wps_status(xml) or "Accepted"
         job.save()
+
+        try:
+            xml = "\n".join(line for line in parseString(xml).toprettyxml().split("\n")
+                            if line.strip())
+        except Exception:  # noqa: BLE001
+            pass
 
         return render(request, "wpsclient/job_run.html", {'job': job,
                                                           "xml" : xml})
+
+    elif job.status not in _JOB_FINISHED:
+        # Already submitted and still running -- checking on it is a poll.
+        return job_status(request, job_pk)
 
     else:
         return job_detail(request, job_pk)

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -160,6 +160,55 @@ def anticipated_outputs(spec, args=None):
     return expected
 
 
+def resolved_output_paths(spec, workspace_dir, args=None):
+    """[(output, absolute path)] for the outputs a run is expected to produce.
+
+    A list of pairs rather than a dict: spec.Output is a pydantic model carrying
+    a set field (VectorOutput.geometry_types), so it is not hashable and cannot
+    be a key.
+
+    Paths come from InVEST's own FileRegistry, which is what applies
+    results_suffix: a suffixed run writes c_storage_bas_gura.tif, not
+    c_storage_bas.tif, so joining ``output.path`` onto the workspace finds
+    nothing whenever a suffix is set -- and the sample datastacks nearly all set
+    one. Output ids containing a bracketed pattern are substituted per run and
+    cannot be resolved generically, so those fall back to the declared path.
+    """
+    # FileRegistry concatenates path + file_suffix + extension, so the separator
+    # has to be part of the suffix: "gura" yields wyieldgura.tif, while InVEST
+    # actually writes wyield_gura.tif. Normalise once and use the same value for
+    # the manual fallback below.
+    suffix = None
+    if args:
+        raw = args.get("results_suffix") or None
+        if raw:
+            suffix = raw if str(raw).startswith("_") else "_%s" % raw
+
+    registry = None
+    try:
+        from natcap.invest.file_registry import FileRegistry
+        registry = FileRegistry(spec.outputs, workspace_dir, file_suffix=suffix)
+    except Exception as exc:  # noqa: BLE001 - fall back to manual suffixing
+        logger.debug("No FileRegistry (%s); suffixing by hand", exc)
+
+    resolved = []
+    for output in anticipated_outputs(spec, args):
+        path = None
+        if registry is not None and "[" not in (output.id or ""):
+            try:
+                path = registry[output.id]
+            except Exception:  # noqa: BLE001 - not every id indexes cleanly
+                path = None
+        if not path:
+            relative = output.path
+            if suffix:
+                stem, ext = os.path.splitext(relative)
+                relative = "%s%s%s" % (stem, suffix, ext)
+            path = os.path.join(workspace_dir, relative)
+        resolved.append((output, path))
+    return resolved
+
+
 def _output_identifier(output):
     """A WPS-safe identifier for a declared output."""
     ident = output.id or os.path.splitext(os.path.basename(output.path))[0]
@@ -288,7 +337,7 @@ class InvestProcess(pywps.Process):
         easyows.Job.run.
         """
         uploads = {}
-        for output in anticipated_outputs(spec, args):
+        for output, path in resolved_output_paths(spec, workspace_dir, args):
             filename = output.path
             lower = filename.lower()
             is_raster = isinstance(output, (invest_spec.SingleBandRasterOutput,
@@ -298,8 +347,7 @@ class InvestProcess(pywps.Process):
                 or lower.endswith((".shp", ".gpkg"))
             if not (is_raster or is_vector):
                 continue
-            path = os.path.join(workspace_dir, filename)
-            base = os.path.splitext(os.path.basename(filename))[0]
+            base = os.path.splitext(os.path.basename(path))[0]
             layer = re.sub(r"[^0-9A-Za-z]+", "_", base).strip("_") or "layer"
             uploads["%s:%s" % (ws, layer)] = path
         return uploads
@@ -368,13 +416,12 @@ class InvestProcess(pywps.Process):
         # actually produced. DescribeProcess has to advertise every output the
         # model can emit, since WPS cannot express a conditional output, so the
         # ones whose created_if did not hold are simply left unset.
-        expected = anticipated_outputs(spec, args)
+        expected = resolved_output_paths(spec, args["workspace_dir"], args)
         filled = 0
-        for output in expected:
+        for output, path in expected:
             identifier = _output_identifier(output)
             if identifier not in response.outputs:
                 continue
-            path = os.path.join(args["workspace_dir"], output.path)
 
             # Must be a regular file. Some declared outputs are directories on
             # disk -- taskgraph_cache/taskgraph.db is declared as a file but


### PR DESCRIPTION
Async job execution, plus a pre-existing bug it exposed.

## Async execution

`job_run` held the HTTP connection open for the entire model run — four minutes for `scenic_quality` — because it submitted synchronously and waited. It now submits with `storeExecuteResponse`, records the `statusLocation`, and returns; a new `job_status` view polls that document and advances the job.

```
run returned in 0.1s -> Accepted
  poll t=4s          -> Succeeded
```

The `statusLocation` has to be **re-hosted** before the dashboard can poll it. `WPS_OUTPUT_URL` is deliberately the published host address — that's what external clients need — but the dashboard is an internal client on the compose network, where that address doesn't resolve. Left alone the poll fails silently and jobs sit on `Accepted` forever, which is exactly what happened on my first attempt.

## The bug that surfaced: nothing was ever published for a suffixed run

`_build_uploads` joined the declared output path onto the workspace. But InVEST writes `wyield_gura.tif`, not `wyield.tif`. So with a `results_suffix` set, every output looked missing:

```
Skipping missing output /tmp/esws-carbon-.../c_storage_bas.tif
END ... anticipated=21 produced=0 published=0
```

**This is not new.** Publishing has been silently empty for every suffixed run, and the sample datastacks nearly all set a suffix — so the model sweep has been reporting `ProcessSucceeded` while publishing **zero layers**. My earlier "24/24 passed" meant the models *ran*, not that they published anything. That correction matters for anything built on top of it.

Paths now come from InVEST's own `FileRegistry`. Its `file_suffix` is concatenated directly — `path + suffix + extension` — so the separator must be part of the value: passing `"gura"` yields `wyieldgura.tif`; it has to be `"_gura"`.

Two further quirks handled: `FileRegistry` *creates* directories when indexed, so it can't be probed against a non-existent path; and `spec.Output` is unhashable (it carries a `set` field), so the resolver returns pairs rather than a dict.

## Verification

| | before | after |
|---|---|---|
| `annual_water_yield` (suffix `gura`) | produced 0, published 0 | **produced 18, published 13** |
| `wave_energy` | — | produced 21, published 18 |
| `wind_energy` | — | produced 9, published 8 |
| job submit | blocks for the whole run | **0.1s**, then poll |

Model sweep still **24 passed, 0 failed** — and now genuinely publishing. `make smoke` 20 passed.

Next up is (C): the upload destination checkbox, the three dropdowns, and Pending → real reconciliation on status refresh — which this async work was the prerequisite for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG