### PR TITLE
Publish model results to servers of your choosing

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,6 @@
 """Django dashboard smoke tests — key views return 200 on Django 4.2."""
 import re
+import time
 
 import pytest
 import requests
@@ -163,6 +164,34 @@ def test_template_form_is_prefilled_from_the_sample_datastack(registered_templat
                          % (dashboard_url, registered_wps_server), timeout=120)
     assert plain.status_code == 200, plain.text[:1000]
     assert 'value="gura"' not in plain.text
+
+
+def test_generated_form_offers_upload_and_destinations(registered_wps_server,
+                                                      dashboard_url):
+    """The wrapper's own inputs render as a checkbox and server pickers.
+
+    They come from DescribeProcess like everything else, but a bare anyURI would
+    render as a text box; the useful destinations are the servers already
+    registered, so they are choices.
+    """
+    r = requests.get("%s/server/%d/execute/carbon/" % (dashboard_url,
+                                                       registered_wps_server),
+                     timeout=120)
+    assert r.status_code == 200, r.text[:1000]
+    assert re.search(r'<input type="checkbox" name="upload_results"', r.text), \
+        r.text[:2000]
+    for kind in ("wcs", "wfs", "http"):
+        assert re.search(r'<select name="destination_%s"' % kind, r.text), kind
+
+
+# The full upload round trip -- anticipated -> Local Pending -> published ->
+# registered -- is not automated here. Driving it needs a *valid* job, and the
+# generated form takes element ids rather than paths, so a test has to pick
+# inputs that genuinely belong together or the model rightly fails. Verified by
+# hand against a loaded demo: carbon with upload_results listed its anticipated
+# outputs under Local Pending WCS/HTTP at Run, and on Succeeded the entries were
+# cleared and results:c_*_willamette appeared on the destination source.
+# Worth automating once there is a fixture that builds a known-good job.
 
 
 def test_dashboard_wps_process_detail(registered_wps_server, dashboard_url):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -184,14 +184,107 @@ def test_generated_form_offers_upload_and_destinations(registered_wps_server,
         assert re.search(r'<select name="destination_%s"' % kind, r.text), kind
 
 
-# The full upload round trip -- anticipated -> Local Pending -> published ->
-# registered -- is not automated here. Driving it needs a *valid* job, and the
-# generated form takes element ids rather than paths, so a test has to pick
-# inputs that genuinely belong together or the model rightly fails. Verified by
-# hand against a loaded demo: carbon with upload_results listed its anticipated
-# outputs under Local Pending WCS/HTTP at Run, and on Succeeded the entries were
-# cleared and results:c_*_willamette appeared on the destination source.
-# Worth automating once there is a fixture that builds a known-good job.
+def _pending_counts(session, dashboard_url, job_pk):
+    """{server type: entries for this job} across the Local Pending sources."""
+    counts = {}
+    for server_type in ("WCS", "WFS", "CSV"):
+        listing = session.get("%s/server/%s/" % (dashboard_url, server_type),
+                              timeout=60).text
+        for row in re.findall(r"<tr>(.*?)</tr>", listing, re.S):
+            if "Local Pending" not in row:
+                continue
+            pk = re.search(r"<td>(\d+)</td>", row).group(1)
+            elements = session.get("%s/server/%s/%s/element/"
+                                   % (dashboard_url, server_type, pk),
+                                   timeout=60).text
+            counts[server_type] = len(re.findall(r"job%d:" % job_pk, elements))
+    return counts
+
+
+def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
+    """anticipated -> Local Pending -> published -> registered, for all three kinds.
+
+    Driven through the Templates source so the model arguments are InVEST's own
+    sample set: the form takes element ids, and picking an arbitrary option per
+    dropdown builds a job that is valid to Django and nonsense to InVEST, which
+    then rightly fails.
+
+    annual_water_yield rather than carbon because it emits rasters, vectors and
+    tables, so every destination kind is exercised in one run.
+    """
+    templates = requests.get(dashboard_url + "/server/TPL/", timeout=30).text
+    template_pk = None
+    for row in re.findall(r"<tr>(.*?)</tr>", templates, re.S):
+        if "InVEST Demo" not in row:
+            continue
+        # The title is a plain cell; the row's own element link carries the pk.
+        found = re.search(r"/server/TPL/(\d+)/element/", row)
+        if found:
+            template_pk = int(found.group(1))
+    if template_pk is None:
+        pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
+
+    session = requests.Session()
+    form_url = "%s/server/%d/execute/annual_water_yield/" % (dashboard_url, template_pk)
+    page = session.get(form_url, timeout=180).text
+    token = re.search(r'name="csrfmiddlewaretoken" value="([^"]+)"', page).group(1)
+
+    data = {"csrfmiddlewaretoken": token, "upload_results": "on"}
+    destinations = {}
+    for match in re.finditer(r'<select name="([a-z_]+)"(.*?)</select>', page, re.S):
+        name, body = match.group(1), match.group(2)
+        if name.startswith("destination_"):
+            option = re.search(r'<option value="(\d+)">', body)
+            if option:
+                destinations[name] = option.group(1)
+            continue
+        chosen = re.search(r'<option value="(\d+)" selected>', body)
+        if chosen:
+            data[name] = chosen.group(1)
+    assert len(destinations) == 3, destinations
+    data.update(destinations)
+
+    for match in re.finditer(r'<input type="[a-z]+" name="([a-z_]+)"[^>]*value="([^"]*)"',
+                             page):
+        if match.group(1) != "csrfmiddlewaretoken" and match.group(2):
+            data.setdefault(match.group(1), match.group(2))
+
+    posted = session.post(form_url, data=data, headers={"Referer": form_url},
+                          timeout=300)
+    assert posted.status_code == 200, posted.text[:1000]
+    job = re.search(r"/job/(\d+)/", posted.url)
+    assert job, "form did not validate: %s" % posted.url
+    job_pk = int(job.group(1))
+
+    session.get("%s/job/%d/run/" % (dashboard_url, job_pk), timeout=180)
+
+    listed = _pending_counts(session, dashboard_url, job_pk)
+    assert listed.get("WCS"), listed
+    assert listed.get("WFS"), listed
+    assert listed.get("CSV"), listed
+
+    for _ in range(60):
+        status = session.get("%s/job/%d/status/" % (dashboard_url, job_pk),
+                             timeout=180).text
+        state = re.search(r"<b>Status: </b>([A-Za-z]+)", status)
+        if state and state.group(1) in ("Succeeded", "Failed"):
+            break
+        time.sleep(4)
+    assert state and state.group(1) == "Succeeded", status[:2000]
+
+    # Every pending entry for this job is gone...
+    cleared = _pending_counts(session, dashboard_url, job_pk)
+    assert not any(cleared.values()), cleared
+
+    # ...and the results are registered against the chosen destinations.
+    for field, server_type, expected in (
+            ("destination_wcs", "WCS", "results:fractp"),
+            ("destination_wfs", "WFS", "results:watershed_results_wyield"),
+            ("destination_http", "CSV", "watershed_results_wyield")):
+        elements = session.get("%s/server/%s/%s/element/"
+                               % (dashboard_url, server_type, destinations[field]),
+                               timeout=120).text
+        assert expected in elements, (server_type, expected, elements[:1500])
 
 
 def test_dashboard_wps_process_detail(registered_wps_server, dashboard_url):

--- a/tools/invest_outputs.py
+++ b/tools/invest_outputs.py
@@ -1,0 +1,108 @@
+"""Working out what an InVEST run will produce, before it runs.
+
+Shared by the WPS wrapper, which needs it to decide what to publish, and by the
+dashboard, which needs it to list a job's anticipated outputs while the job is
+still queued. Kept free of pywps and easyows so the dashboard can import it
+without dragging the server stack in.
+"""
+import logging
+import os
+
+logger = logging.getLogger("invest_outputs")
+
+
+class _Falsey(dict):
+    """Missing names are False, not an error."""
+
+    def __missing__(self, key):
+        return False
+
+
+def output_is_expected(output, args):
+    """Whether ``output``'s created_if condition holds for ``args``.
+
+    created_if is either a bool or an expression naming other inputs, e.g.
+    "sub_watersheds_path" or "do_valuation and (not price_table)". An input the
+    caller never supplied is falsey -- that is the whole point of the condition,
+    and evaluating it as a NameError would wrongly mark the output as expected.
+    """
+    condition = getattr(output, "created_if", True)
+    if isinstance(condition, bool):
+        return condition
+    if args is None:
+        return True
+    env = _Falsey((key, bool(value)) for key, value in args.items())
+    try:
+        return bool(eval(condition, {"__builtins__": {}}, env))  # noqa: S307
+    except Exception:  # noqa: BLE001 - an unparseable condition is not fatal
+        logger.debug("Could not evaluate created_if %r; assuming produced",
+                     condition)
+        return True
+
+
+def anticipated_outputs(spec, args=None):
+    """The file outputs a run with ``args`` is expected to produce.
+
+    With args omitted this is every file output the model declares, which is
+    what DescribeProcess has to advertise -- WPS has no way to say that an
+    output only appears under some conditions.
+    """
+    expected = []
+    for output in spec.outputs:
+        # Only file outputs have a workspace-relative path; numeric and string
+        # outputs are metadata with nothing to fetch or publish.
+        if not getattr(output, "path", None):
+            continue
+        if not output_is_expected(output, args):
+            continue
+        expected.append(output)
+    return expected
+
+
+def resolved_output_paths(spec, workspace_dir, args=None):
+    """[(output, absolute path)] for the outputs a run is expected to produce.
+
+    A list of pairs rather than a dict: spec.Output is a pydantic model carrying
+    a set field (VectorOutput.geometry_types), so it is not hashable and cannot
+    be a key.
+
+    Paths come from InVEST's own FileRegistry, which is what applies
+    results_suffix: a suffixed run writes c_storage_bas_gura.tif, not
+    c_storage_bas.tif, so joining ``output.path`` onto the workspace finds
+    nothing whenever a suffix is set -- and the sample datastacks nearly all set
+    one. Output ids containing a bracketed pattern are substituted per run and
+    cannot be resolved generically, so those fall back to the declared path.
+    """
+    # FileRegistry concatenates path + file_suffix + extension, so the separator
+    # has to be part of the suffix: "gura" yields wyieldgura.tif, while InVEST
+    # actually writes wyield_gura.tif. Normalise once and use the same value for
+    # the manual fallback below.
+    suffix = None
+    if args:
+        raw = args.get("results_suffix") or None
+        if raw:
+            suffix = raw if str(raw).startswith("_") else "_%s" % raw
+
+    registry = None
+    try:
+        from natcap.invest.file_registry import FileRegistry
+        registry = FileRegistry(spec.outputs, workspace_dir, file_suffix=suffix)
+    except Exception as exc:  # noqa: BLE001 - fall back to manual suffixing
+        logger.debug("No FileRegistry (%s); suffixing by hand", exc)
+
+    resolved = []
+    for output in anticipated_outputs(spec, args):
+        path = None
+        if registry is not None and "[" not in (output.id or ""):
+            try:
+                path = registry[output.id]
+            except Exception:  # noqa: BLE001 - not every id indexes cleanly
+                path = None
+        if not path:
+            relative = output.path
+            if suffix:
+                stem, ext = os.path.splitext(relative)
+                relative = "%s%s%s" % (stem, suffix, ext)
+            path = os.path.join(workspace_dir, relative)
+        resolved.append((output, path))
+    return resolved

--- a/tools/wpsclient/wpsclient/forms.py
+++ b/tools/wpsclient/wpsclient/forms.py
@@ -93,7 +93,9 @@ class testForm(forms.Form):
 ##
 
 
-_INVEST_TRAILER = re.compile(r"\[invest:([^\]]*)\]")
+# Both the InVEST type trailer and the wrapper's own esws: trailer.
+_TRAILER = re.compile(r"\[(?:invest|esws):[^\]]*\]")
+_TRAILER_TOKEN = re.compile(r"(invest|esws):(\w+)=([^\s\]]+)")
 
 
 def parse_input_metadata(parameter):
@@ -105,13 +107,9 @@ def parse_input_metadata(parameter):
     """
     abstract = parameter.abstract or ""
     meta = {}
-    match = _INVEST_TRAILER.search(abstract)
-    if match:
-        for token in ("invest:" + match.group(1)).split():
-            key, _sep, value = token.partition("=")
-            if value:
-                meta[key.replace("invest:", "")] = value
-        abstract = _INVEST_TRAILER.sub("", abstract).strip()
+    for ns, key, value in _TRAILER_TOKEN.findall(abstract):
+        meta["%s:%s" % (ns, key) if ns == "esws" else key] = value
+    abstract = _TRAILER.sub("", abstract).strip()
     return abstract, meta
 
 
@@ -127,6 +125,14 @@ class ProcessForm(forms.Form):
     yield form encoded by hand in its ForeignKeys: rasters come from WCS,
     vectors from WFS, tables over plain HTTP.
     """
+
+    # Which registered server type can serve as a destination for each output
+    # kind the wrapper asks about.
+    DESTINATION_SOURCES = {
+        "raster": ServerWCS,
+        "vector": ServerWFS,
+        "table": ServerCSV,
+    }
 
     ELEMENT_SOURCES = {
         "raster": ElementWCS,
@@ -145,6 +151,10 @@ class ProcessForm(forms.Form):
         # URL, and so it knows which fields are element references at all.
         self.element_fields = {}
 
+        # Destination pickers, so the view can turn the chosen server into the
+        # anyURI the WPS expects.
+        self.destination_fields = {}
+
         for parameter in parameters:
             abstract, meta = parse_input_metadata(parameter)
             invest_type = meta.get("type", "")
@@ -158,6 +168,21 @@ class ProcessForm(forms.Form):
                 "required": str(getattr(parameter, "minOccurs", 0)) not in ("0", "None"),
             }
 
+            # The wrapper's own inputs: a checkbox and one server picker per
+            # output kind. Rendered as choices rather than free-text URLs
+            # because the useful destinations are the ones already registered.
+            kind = meta.get("esws:destination")
+            if kind:
+                destination = self.DESTINATION_SOURCES.get(kind)
+                if destination is not None:
+                    common["required"] = False
+                    self.fields[identifier] = forms.ModelChoiceField(
+                        queryset=destination.objects.filter(
+                            is_pending=False).order_by("title"),
+                        empty_label="---------", **common)
+                    self.destination_fields[identifier] = kind
+                    continue
+
             source = self.ELEMENT_SOURCES.get(invest_type)
             if source is not None:
                 self.fields[identifier] = forms.ModelChoiceField(
@@ -168,7 +193,7 @@ class ProcessForm(forms.Form):
                 self.fields[identifier] = forms.FloatField(**common)
             elif invest_type == "integer":
                 self.fields[identifier] = forms.IntegerField(**common)
-            elif invest_type == "boolean":
+            elif invest_type == "boolean" or parameter.dataType == "boolean":
                 common["required"] = False
                 self.fields[identifier] = forms.BooleanField(**common)
             elif getattr(parameter, "allowedValues", None):

--- a/tools/wpsclient/wpsclient/models.py
+++ b/tools/wpsclient/wpsclient/models.py
@@ -36,6 +36,11 @@ class Server(models.Model):
     registrations = models.IntegerField(default=0)
     jobs = models.IntegerField(default=0)
 
+    # A holding area rather than a real endpoint: the "Local Pending" sources
+    # list a job's anticipated outputs until the run produces them. Excluded
+    # from destination pickers, since nothing can be published to them.
+    is_pending = models.BooleanField(default=False)
+
     def publish(self):
         self.save()
 

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -147,12 +147,18 @@ def server_register(request, server_type, title, url):
 
     ServerClass = server_dict[server_type]
 
-    # Keyed on the URL so re-registering a source updates rather than
-    # duplicating it -- the demo loader is meant to be safe to re-run.
-    server, created = ServerClass.objects.get_or_create(
-        url=url, defaults={"title": title})
-    if not created and server.title != title:
-        server.title = title
+    # Keyed on title *and* URL so re-registering updates rather than
+    # duplicating -- the demo loader is meant to be safe to re-run. URL alone is
+    # not unique: a template shares its WPS's URL, and since ServerTemplate
+    # subclasses ServerWPS both satisfy a ServerWPS lookup, so keying on the URL
+    # matched two rows and raised MultipleObjectsReturned on the second run.
+    candidates = ServerClass.objects.filter(url=url, title=title)
+    if server_type == "WPS":
+        candidates = candidates.filter(servertemplate__isnull=True)
+
+    server = candidates.first()
+    if server is None:
+        server = ServerClass(title=title, url=url)
         server.save()
 
     return server_detail(request, server.pk, server_type)
@@ -316,9 +322,14 @@ def server_element_list(request, server_type, server_pk):
     registered_element_list.sort()
     
     unregistered_element_list = []
-    for identifier in get_list(server.url):
-        if not (identifier in registered_element_list):
-            unregistered_element_list.append(identifier)
+    # A "Local Pending" source is a holding area, not a live endpoint: it lists
+    # what a running job is expected to produce. Asking it for its contents the
+    # usual way means contacting a URL that does not resolve, which 500s the
+    # page -- so only the registered entries are shown.
+    if not server.is_pending:
+        for identifier in get_list(server.url):
+            if not (identifier in registered_element_list):
+                unregistered_element_list.append(identifier)
     
     return render(request, 'wpsclient/server_element_list.html', {'server': server,
                                                                   'registered_element_list' : registered_element_list,
@@ -595,6 +606,144 @@ def job_validate(request, job_pk):
     return dashboard(request)
 
   
+# Output kind -> (pending server title, server class, element class)
+PENDING_SOURCES = {
+    "raster": ("Local Pending WCS", ServerWCS, ElementWCS),
+    "vector": ("Local Pending WFS", ServerWFS, ElementWFS),
+    "table": ("Local Pending HTTP", ServerCSV, ElementCSV),
+}
+
+
+def pending_server(kind):
+    """The holding source for a kind of anticipated output, created on demand."""
+    entry = PENDING_SOURCES.get(kind)
+    if entry is None:
+        return None, None
+    title, ServerClass, ElementClass = entry
+    server, _created = ServerClass.objects.get_or_create(
+        title=title, defaults={"url": "http://pending.invalid/%s" % kind,
+                               "is_pending": True})
+    if not server.is_pending:
+        server.is_pending = True
+        server.save()
+    return server, ElementClass
+
+
+def anticipated_for_job(job):
+    """[(kind, name)] this job is expected to produce.
+
+    Computed from MODEL_SPEC the same way the WPS computes what to publish --
+    created_if evaluated against the job's own arguments, and results_suffix
+    applied -- so the pending list matches what actually turns up.
+    """
+    scripts = "/app/tools"
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    try:
+        from invest_outputs import resolved_output_paths
+        from natcap.invest import models as invest_models_registry
+    except Exception:  # noqa: BLE001 - not an InVEST server: nothing to predict
+        return []
+
+    spec = invest_models_registry.model_id_to_spec.get(job.identifier)
+    if spec is None:
+        return []
+
+    # Only the argument values matter for created_if and the suffix, so the
+    # workspace is irrelevant here; names are taken from the resolved basenames.
+    out = []
+    for output, resolved in resolved_output_paths(spec, "/anticipated", job.args):
+        lower = resolved.lower()
+        if lower.endswith((".tif", ".tiff")):
+            kind = "raster"
+        elif lower.endswith((".shp", ".gpkg")):
+            kind = "vector"
+        elif lower.endswith(".csv"):
+            kind = "table"
+        else:
+            continue
+        name = path.basename(resolved)
+        if kind != "table":
+            name = path.splitext(name)[0]
+        out.append((kind, name))
+    return out
+
+
+def register_pending(job):
+    """List a job's anticipated outputs under the Local Pending sources."""
+    if not any(job.args.get(field) for field in
+               ("destination_wcs", "destination_wfs", "destination_http")):
+        return 0
+
+    added = 0
+    for kind, name in anticipated_for_job(job):
+        server, ElementClass = pending_server(kind)
+        if server is None:
+            continue
+        # Scoped by job: two runs of one model anticipate identical names, and a
+        # failed run's entries stay listed under its own job id.
+        identifier = "job%s:%s" % (job.pk, name)
+        _element, created = ElementClass.objects.get_or_create(
+            server=server, identifier=identifier)
+        added += int(created)
+    return added
+
+
+def clear_pending(job):
+    """Drop this job's pending entries once its outputs are real."""
+    removed = 0
+    prefix = "job%s:" % job.pk
+    for _title, _ServerClass, ElementClass in PENDING_SOURCES.values():
+        removed += ElementClass.objects.filter(
+            server__is_pending=True, identifier__startswith=prefix).delete()[0]
+    return removed
+
+
+def reconcile_uploads(job, xml):
+    """Turn a finished job's anticipated outputs into registered ones.
+
+    The WPS reports what it published in its `uploaded` output -- entries of
+    <kind>:<workspace>:<name>, or table:<filename> -- so the client reconciles
+    from the response instead of the server calling back into it.
+    """
+    match = re.search(r"uploaded</ows:Identifier>.*?<wps:LiteralData[^>]*>"
+                      r"([^<]*)</wps:LiteralData>", xml, re.S)
+    if not match:
+        return 0
+    entries = [e for e in match.group(1).strip().split(";") if e]
+
+    registered = 0
+    for entry in entries:
+        bits = entry.split(":")
+        kind = bits[0]
+        identifier = ":".join(bits[1:])
+        if not identifier:
+            continue
+
+        destination_url = job.args.get(
+            {"raster": "destination_wcs", "vector": "destination_wfs",
+             "table": "destination_http"}.get(kind, ""))
+        if not destination_url:
+            continue
+
+        entry_map = PENDING_SOURCES.get(kind)
+        if entry_map is None:
+            continue
+        _title, ServerClass, ElementClass = entry_map
+        server = ServerClass.objects.filter(url=destination_url,
+                                            is_pending=False).first()
+        if server is None:
+            continue
+
+        _element, created = ElementClass.objects.get_or_create(
+            server=server, identifier=identifier)
+        registered += int(created)
+
+    if entries:
+        clear_pending(job)
+    return registered
+
+
 def template_initial(process_id):
     """Initial form values for a template source: InVEST's own sample arguments.
 
@@ -694,7 +843,10 @@ def job_new(request, server_pk, process_id):
             for name, value in form.cleaned_data.items():
                 if value is None or value == "":
                     continue
-                if name in form.element_fields:
+                if name in getattr(form, "destination_fields", {}):
+                    # The WPS wants the endpoint, not our row id.
+                    value = value.url
+                elif name in form.element_fields:
                     # A chosen data source becomes the URL the WPS will fetch,
                     # the same conversion the water yield form used to do.
                     value = get_ows_data_url(value.element_type,
@@ -877,6 +1029,14 @@ def job_status(request, job_pk):
             job.status = state
             job.save()
 
+        if state == "Succeeded":
+            try:
+                reconcile_uploads(job, xml)
+            except Exception as exc:  # noqa: BLE001 - polling must still work
+                l = logging.getLogger("django.request")
+                l.warning("Could not reconcile uploads for job %s: %s",
+                          job.pk, exc)
+
     if xml.startswith("<?xml") or xml.startswith("<wps"):
         try:
             xml = "\n".join(line for line in parseString(xml).toprettyxml().split("\n")
@@ -908,6 +1068,13 @@ def job_run(request, job_pk):
             job.save()
             return render(request, "wpsclient/job_run.html",
                           {"job": job, "xml": "submit failed: %s" % exc})
+
+        # Anticipated outputs are listed once the run is actually submitted --
+        # a job that is only saved may never be run.
+        try:
+            register_pending(job)
+        except Exception as exc:  # noqa: BLE001 - never block a submission
+            l.warning("Could not list anticipated outputs: %s", exc)
 
         location = re.search(r'statusLocation="([^"]+)"', xml)
         if location:

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -39,6 +39,52 @@ logger = logging.getLogger("invest_models")
 # Args the wrapper sets itself; never exposed as WPS inputs.
 _SKIP_ARGS = {"workspace_dir", "n_workers"}
 
+# Inputs this wrapper adds on top of the model's own. They control where results
+# are published and must never reach the model's execute().
+UPLOAD_FLAG = "upload_results"
+DESTINATION_INPUTS = {
+    "raster": "destination_wcs",
+    "vector": "destination_wfs",
+    "table": "destination_http",
+}
+_WRAPPER_ARGS = {UPLOAD_FLAG} | set(DESTINATION_INPUTS.values())
+
+# Workspace results are published into on a destination server. Stable rather
+# than per-job so registered layer names are predictable; results_suffix is what
+# keeps successive runs apart.
+_RESULTS_WORKSPACE = os.environ.get("WPS_RESULTS_WORKSPACE", "results")
+
+
+def _upload_inputs():
+    """The wrapper's own inputs: whether to upload results, and where to.
+
+    anyURI rather than string -- these are endpoints, and it is the standard
+    xmlschema type for one, so a client can treat them as URLs. The values are
+    supplied by the client from whatever servers it knows about; the WPS does not
+    keep a list of permitted destinations.
+    """
+    inputs = [pywps.LiteralInput(
+        identifier=UPLOAD_FLAG,
+        title="Upload model results",
+        abstract="Publish this run's outputs to the destination servers below "
+                 "in addition to returning them.\n\n[esws:wrapper=1]",
+        data_type="boolean",
+        min_occurs=0,
+        max_occurs=1,
+    )]
+    for kind, identifier in sorted(DESTINATION_INPUTS.items()):
+        inputs.append(pywps.LiteralInput(
+            identifier=identifier,
+            title="Destination for %s outputs" % kind,
+            abstract="Base URL of the server %s outputs are published to when "
+                     "%s is set.\n\n[esws:wrapper=1 esws:destination=%s]"
+                     % (kind, UPLOAD_FLAG, kind),
+            data_type="anyURI",
+            min_occurs=0,
+            max_occurs=1,
+        ))
+    return inputs
+
 # Model workspaces are created here. In the container this points at a volume
 # shared with GeoServer (so GeoServer can read raster outputs by file path).
 _WORKSPACE_ROOT = os.environ.get("WPS_WORKSPACE_ROOT", tempfile.gettempdir())
@@ -293,9 +339,19 @@ class InvestProcess(pywps.Process):
         # published WMS URLs and existing clients read it. The per-output
         # ComplexOutputs are the real declaration -- WPS supports any number of
         # outputs, and until now every model advertised only this one string.
+        inputs.extend(_upload_inputs())
+
         outputs = [pywps.LiteralOutput("response",
                                        "Published layers or workspace path",
                                        data_type="string")]
+        outputs.append(pywps.LiteralOutput(
+            "uploaded",
+            "Layers published to the destination servers",
+            abstract="Semicolon-separated <kind>:<identifier> entries for what "
+                     "was published when upload_results was set. Empty "
+                     "otherwise. A client uses it to turn anticipated outputs "
+                     "into registered ones.",
+            data_type="string"))
         outputs.extend(_complex_outputs(spec))
 
         abstract = (module.__doc__ or spec.model_title or model_id or "").strip()
@@ -316,7 +372,7 @@ class InvestProcess(pywps.Process):
         args = {}
         for inp in spec.inputs:
             arg_id = inp.id
-            if arg_id in _SKIP_ARGS:
+            if arg_id in _SKIP_ARGS or arg_id in _WRAPPER_ARGS:
                 continue
             if arg_id in request.inputs and len(request.inputs[arg_id]):
                 value = request.inputs[arg_id][0].data
@@ -351,6 +407,106 @@ class InvestProcess(pywps.Process):
             layer = re.sub(r"[^0-9A-Za-z]+", "_", base).strip("_") or "layer"
             uploads["%s:%s" % (ws, layer)] = path
         return uploads
+
+    def _wrapper_arg(self, request, identifier):
+        """One of this wrapper's own inputs, or None if it was not supplied.
+
+        pywps parses an anyURI input into a urllib ParseResult rather than a
+        string, so it is put back together here -- otherwise it reaches easyows
+        as an object and string concatenation fails.
+        """
+        values = request.inputs.get(identifier) or []
+        if not values:
+            return None
+        value = values[0].data
+        if hasattr(value, "geturl"):
+            value = value.geturl()
+        return value if value not in ("", None) else None
+
+    def _upload_to_destinations(self, request, spec, args):
+        """Publish this run's outputs to the client-chosen servers.
+
+        Returns ["<kind>:<identifier>", ...] describing what landed where, which
+        goes back in the `uploaded` output. The client reconciles from that
+        rather than the WPS calling into it -- nothing here knows or needs to
+        know that a dashboard exists.
+
+        Deliberately separate from the per-job publish easyows.Job already does:
+        that one exists so a run's results are viewable at all, whereas this is
+        the user asking for them to be kept somewhere of their choosing.
+        """
+        flag = self._wrapper_arg(request, UPLOAD_FLAG)
+        if not (flag is True or str(flag).lower() in ("true", "1", "yes")):
+            return []
+
+        destinations = {kind: self._wrapper_arg(request, identifier)
+                        for kind, identifier in DESTINATION_INPUTS.items()}
+        if not any(destinations.values()):
+            logger.warning("%s set but no destination given", UPLOAD_FLAG)
+            return []
+
+        # One catalog per distinct GeoServer base, so rasters and vectors can go
+        # to different servers if the client chose differently.
+        catalogs, uploaded = {}, []
+
+        def catalog_for(base):
+            if base not in catalogs:
+                catalogs[base] = easyows.Catalog(
+                    gs_url=base,
+                    username=os.environ.get("GEOSERVER_USER", "admin"),
+                    password=os.environ.get("GEOSERVER_PASS", "geoserver"),
+                    logger=logger)
+                try:
+                    existing = {w.name for w in catalogs[base].gs_cat.get_workspaces()}
+                    if _RESULTS_WORKSPACE not in existing:
+                        catalogs[base].gs_cat.create_workspace(
+                            _RESULTS_WORKSPACE, "http://esws/%s" % _RESULTS_WORKSPACE)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Could not prepare workspace on %s: %s",
+                                   base, str(exc)[:200])
+            return catalogs[base]
+
+        for output, path in resolved_output_paths(spec, args["workspace_dir"], args):
+            if not os.path.isfile(path):
+                continue
+            lower = path.lower()
+            if lower.endswith((".tif", ".tiff")):
+                kind = "raster"
+            elif lower.endswith((".shp", ".gpkg")):
+                kind = "vector"
+            elif lower.endswith(".csv"):
+                kind = "table"
+            else:
+                continue
+
+            base = destinations.get(kind)
+            if not base:
+                continue
+
+            name = re.sub(r"[^0-9A-Za-z]+", "_",
+                          os.path.splitext(os.path.basename(path))[0]).strip("_")
+            if kind == "table":
+                # There is no upload protocol for a plain file server, so a table
+                # is offered where it already is: the WPS serves its own outputs.
+                uploaded.append("table:%s" % os.path.basename(path))
+                continue
+
+            try:
+                cat = catalog_for(base)
+                if kind == "raster":
+                    cat.publish_tif(path, name, _RESULTS_WORKSPACE)
+                elif lower.endswith(".gpkg"):
+                    cat.publish_gpkg(path, name, _RESULTS_WORKSPACE)
+                else:
+                    cat.publish_shp(path, name, _RESULTS_WORKSPACE)
+            except Exception as exc:  # noqa: BLE001 - report the rest regardless
+                logger.warning("Could not publish %s to %s: %s",
+                               name, base, str(exc)[:200])
+                continue
+            uploaded.append("%s:%s:%s" % (kind, _RESULTS_WORKSPACE, name))
+
+        logger.info("Uploaded %d outputs to client destinations", len(uploaded))
+        return uploaded
 
     def _handler(self, request, response):
         logger.info("BEGIN InVEST WPS model=%s", self.model_id)
@@ -399,6 +555,10 @@ class InvestProcess(pywps.Process):
             raise pywps.exceptions.NoApplicableCode(
                 "Could not resolve all inputs for %s; the model did not run"
                 % self.model_id)
+
+        uploaded = self._upload_to_destinations(request, spec, args)
+        response.outputs["uploaded"].data = ";".join(uploaded)
+        response.outputs["uploaded"].uom = pywps.UOM("unity")
 
         gs_url = os.environ.get(
             "GEOSERVER_PUBLIC_URL",

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -29,6 +29,8 @@ import pywps
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 import easyows
+from invest_outputs import (anticipated_outputs, output_is_expected,
+                            resolved_output_paths)
 
 import natcap.invest
 from natcap.invest import models
@@ -157,102 +159,6 @@ _OUTPUT_FORMATS = {
 }
 _DEFAULT_OUTPUT_FORMAT = "application/octet-stream"
 
-
-class _Falsey(dict):
-    """Missing names are False, not an error."""
-
-    def __missing__(self, key):
-        return False
-
-
-def output_is_expected(output, args):
-    """Whether ``output``'s created_if condition holds for ``args``.
-
-    created_if is either a bool or an expression naming other inputs, e.g.
-    "sub_watersheds_path" or "do_valuation and (not price_table)". An input the
-    caller never supplied is falsey -- that is the whole point of the condition,
-    and evaluating it as a NameError would wrongly mark the output as expected.
-    """
-    condition = getattr(output, "created_if", True)
-    if isinstance(condition, bool):
-        return condition
-    if args is None:
-        return True
-    env = _Falsey((key, bool(value)) for key, value in args.items())
-    try:
-        return bool(eval(condition, {"__builtins__": {}}, env))  # noqa: S307
-    except Exception:  # noqa: BLE001 - an unparseable condition is not fatal
-        logger.debug("Could not evaluate created_if %r; assuming produced",
-                     condition)
-        return True
-
-
-def anticipated_outputs(spec, args=None):
-    """The file outputs a run with ``args`` is expected to produce.
-
-    With args omitted this is every file output the model declares, which is
-    what DescribeProcess has to advertise -- WPS has no way to say that an
-    output only appears under some conditions.
-    """
-    expected = []
-    for output in spec.outputs:
-        # Only file outputs have a workspace-relative path; numeric and string
-        # outputs are metadata with nothing to fetch or publish.
-        if not getattr(output, "path", None):
-            continue
-        if not output_is_expected(output, args):
-            continue
-        expected.append(output)
-    return expected
-
-
-def resolved_output_paths(spec, workspace_dir, args=None):
-    """[(output, absolute path)] for the outputs a run is expected to produce.
-
-    A list of pairs rather than a dict: spec.Output is a pydantic model carrying
-    a set field (VectorOutput.geometry_types), so it is not hashable and cannot
-    be a key.
-
-    Paths come from InVEST's own FileRegistry, which is what applies
-    results_suffix: a suffixed run writes c_storage_bas_gura.tif, not
-    c_storage_bas.tif, so joining ``output.path`` onto the workspace finds
-    nothing whenever a suffix is set -- and the sample datastacks nearly all set
-    one. Output ids containing a bracketed pattern are substituted per run and
-    cannot be resolved generically, so those fall back to the declared path.
-    """
-    # FileRegistry concatenates path + file_suffix + extension, so the separator
-    # has to be part of the suffix: "gura" yields wyieldgura.tif, while InVEST
-    # actually writes wyield_gura.tif. Normalise once and use the same value for
-    # the manual fallback below.
-    suffix = None
-    if args:
-        raw = args.get("results_suffix") or None
-        if raw:
-            suffix = raw if str(raw).startswith("_") else "_%s" % raw
-
-    registry = None
-    try:
-        from natcap.invest.file_registry import FileRegistry
-        registry = FileRegistry(spec.outputs, workspace_dir, file_suffix=suffix)
-    except Exception as exc:  # noqa: BLE001 - fall back to manual suffixing
-        logger.debug("No FileRegistry (%s); suffixing by hand", exc)
-
-    resolved = []
-    for output in anticipated_outputs(spec, args):
-        path = None
-        if registry is not None and "[" not in (output.id or ""):
-            try:
-                path = registry[output.id]
-            except Exception:  # noqa: BLE001 - not every id indexes cleanly
-                path = None
-        if not path:
-            relative = output.path
-            if suffix:
-                stem, ext = os.path.splitext(relative)
-                relative = "%s%s%s" % (stem, suffix, ext)
-            path = os.path.join(workspace_dir, relative)
-        resolved.append((output, path))
-    return resolved
 
 
 def _output_identifier(output):


### PR DESCRIPTION
The upload feature, both halves.

## WPS side

Every process gains four inputs of its own, kept out of the model's `execute()`:

```
upload_results    boolean
destination_wcs   anyURI    ← rasters
destination_wfs   anyURI    ← vectors
destination_http  anyURI    ← tables
```

`anyURI` because these are endpoints and that is the standard xmlschema type for one. **No `ows:AllowedValues`** — the client supplies the URL from whatever servers it knows about; the WPS keeps no list.

When the flag is set, outputs are published into a stable `results` workspace on each chosen server, one catalog per distinct base so rasters and vectors can go to different servers. What landed where comes back in a new `uploaded` output. **No callback**: the server reports, the client reconciles, so the WPS still knows nothing about a dashboard.

Additive — the per-job publish `easyows.Job` already does is untouched.

## Dashboard side

The four inputs arrived automatically from DescribeProcess, but a bare `anyURI` renders as a text box. They now render as a checkbox plus one **server picker per output kind**, last in the form; the chosen server becomes the `anyURI`.

Three holding sources — **Local Pending WCS / WFS / HTTP** — are created on demand and populated at Run from the same `created_if` and `results_suffix` handling the WPS uses, so the list matches what turns up. Entries are scoped `job<pk>:<name>`: two runs of one model anticipate identical names, and a failed run's entries stay listed under its own job — that is the marking, no extra flag.

On Succeeded, `job_status` reads `uploaded`, registers the real elements against the destination the job recorded, and clears that job's pending entries.

Prediction logic moved to `tools/invest_outputs.py`, free of pywps and easyows, so the dashboard imports it without the server stack.

## The round trip, tested

Automated with **annual_water_yield** — it emits rasters, vectors *and* tables, so one run covers all three kinds:

| Local Pending | after Run | after Succeeded |
|---|---|---|
| WCS | 36 | **0** |
| WFS | 6 | **0** |
| HTTP | 6 | **0** |

Registered on the destinations: `results:fractp_gura`, `results:watershed_results_wyield_gura`, `watershed_results_wyield_gura.csv`.

It is driven through the Templates source so the arguments are InVEST's own sample set — that is what makes a submittable job available to a test at all. It skips when the demo isn't loaded, since its inputs must have been published first, and `make smoke` runs unseeded: **21 passed, 1 skipped** there, **1 passed** against a loaded demo.

## Two bugs fixed on the way

- `server_register` keyed `get_or_create` on the URL alone, which broke once a template shared its WPS's URL — `ServerTemplate` subclasses `ServerWPS`, so both satisfy the lookup and the *second* `make demo` raised `MultipleObjectsReturned`. Now keyed on title and URL.
- `server_element_list` contacted the source to enumerate contents, which 500s for a pending source whose URL is a placeholder.

## Known limitation

`destination_http` **reports** tables where they already are rather than uploading — there is no upload protocol for a plain file server. Making it a real target is the pygeoapi + OGC API Joins work queued next; the input means that becomes a backend swap, not a redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG