### PR TITLE
Publish only results, and make table outputs a real upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ sample.csv
 shape_join.*
 src
 .env
+# mountpoint for the results_tables volume (see docker-compose.yml)
+data/results/

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ logs:         ## Follow logs from all services
 smoke:        ## Build, start the stack, run the pytest smoke suite, tear down
 	./scripts/smoke.sh
 
+smoke-demo:   ## smoke, but with the demo data loaded so no test skips
+	DEMO=1 ./scripts/smoke.sh
+
 demo-data:    ## Download + unpack the InVEST sample datasets (cached, ~380MB)
 	./scripts/fetch_invest_samples.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       # InVEST sample data, cached outside the repo by
       # scripts/fetch_invest_samples.sh. Read-only: it is reference data.
       - ${INVEST_SAMPLES:-/store/invest/samples}:/data/invest:ro
+      # Shared with fileserver, which publishes it at /results/: gives table
+      # outputs somewhere to be uploaded *to*, since a plain file server has no
+      # upload protocol of its own.
+      - results_tables:/app/data/results
     environment:
       GEOSERVER_URL: http://geoserver:8080/geoserver
       # Advertised to WPS clients in the WMS URLs of published layers, so it has
@@ -36,6 +40,8 @@ services:
       # statusLocation and asReference URLs are handed to clients, so they must
       # use the host mapping rather than the container port.
       WPS_OUTPUT_URL: http://localhost:${WPS_HOST_PORT:-5000}/outputs
+      WPS_TABLE_UPLOAD_DIR: /app/data/results
+      WPS_TABLE_UPLOAD_PATH: results
     depends_on:
       - geoserver
 
@@ -54,6 +60,8 @@ services:
       # Served under /invest/, so demo tables (CSVs) have an HTTP URL the
       # dashboard can register as CSV elements.
       - ${INVEST_SAMPLES:-/store/invest/samples}:/app/data/invest:ro
+      # Table outputs the wps uploads, published at /results/. See wps.
+      - results_tables:/app/data/results:ro
 
   dashboard:
     image: esws/wps  # see fileserver
@@ -67,6 +75,10 @@ services:
       # Read by the Templates source to prefill job forms with the sample
       # arguments recorded in InVEST's datastacks.
       - ${INVEST_SAMPLES:-/store/invest/samples}:/data/invest:ro
+      # Shared with fileserver, which publishes it at /results/: gives table
+      # outputs somewhere to be uploaded *to*, since a plain file server has no
+      # upload protocol of its own.
+      - results_tables:/app/data/results
     environment:
       DJANGO_ALLOWED_HOSTS: "*"
       DJANGO_DB_PATH: /tmp/esws-db.sqlite3
@@ -88,5 +100,6 @@ services:
 
 volumes:
   wps_outputs:
+  results_tables:
   gisdata:
   geoserver_data:

--- a/docker/Dockerfile.invest
+++ b/docker/Dockerfile.invest
@@ -56,6 +56,11 @@ RUN mkdir -p /tmp/wpsoutputs
 COPY --chown=$MAMBA_USER:$MAMBA_USER . /app
 WORKDIR /app
 
+# Upload target for table outputs, shared with the fileserver as a named volume.
+# Created here for the same ownership reason as /tmp/wpsoutputs above -- and it
+# has to be after the COPY, which would otherwise replace the directory.
+RUN mkdir -p /app/data/results
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app/tools
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -8,6 +8,9 @@
 #
 # Env:
 #   KEEP_UP=1   leave the stack running after the tests (default: tear down)
+#   DEMO=1      load the demo data first, so the tests that need registered
+#               sample data run instead of skipping (adds a few minutes, and
+#               downloads ~2GB of InVEST samples on a cold cache)
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -16,6 +19,12 @@ docker compose build
 
 echo ">> Starting stack"
 docker compose up -d
+
+if [ "${DEMO:-0}" = "1" ]; then
+  echo ">> Loading demo data"
+  ./scripts/fetch_invest_samples.sh
+  docker compose run --rm --no-deps wps python scripts/load_demo.py
+fi
 
 cleanup() {
   if [ "${KEEP_UP:-0}" != "1" ]; then
@@ -30,4 +39,5 @@ docker compose run --rm --no-deps \
   -e WPS_URL=http://wps:5000/wps \
   -e DASHBOARD_URL=http://dashboard:8000 \
   -e GEOSERVER_URL=http://geoserver:8080/geoserver \
+  -e FILESERVER_URL=http://fileserver:8001 \
   wps sh -c "pip install --quiet -r requirements/dev.txt && python -m pytest tests/ -v"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,6 @@
 """Django dashboard smoke tests — key views return 200 on Django 4.2."""
+import html
+import os
 import re
 import time
 
@@ -276,15 +278,41 @@ def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
     cleared = _pending_counts(session, dashboard_url, job_pk)
     assert not any(cleared.values()), cleared
 
+    # What the WPS says it published. Reported on failure below so a miss reads as
+    # "the server published nothing" or "published but the client did not
+    # register it" without digging through the server log.
+    # The status page embeds the ExecuteResponse as escaped markup, so unescape
+    # before matching -- searching the raw HTML for <wps:LiteralData never hits.
+    reported = re.search(r"uploaded</ows:Identifier>.*?<wps:LiteralData[^>]*>"
+                         r"([^<]*)</wps:LiteralData>", html.unescape(status), re.S)
+    reported = reported.group(1).strip() if reported else "<no uploaded output>"
+
     # ...and the results are registered against the chosen destinations.
+    registered = {}
     for field, server_type, expected in (
             ("destination_wcs", "WCS", "results:fractp"),
             ("destination_wfs", "WFS", "results:watershed_results_wyield"),
-            ("destination_http", "CSV", "watershed_results_wyield")):
+            ("destination_http", "CSV", "results/watershed_results_wyield")):
         elements = session.get("%s/server/%s/%s/element/"
                                % (dashboard_url, server_type, destinations[field]),
                                timeout=120).text
-        assert expected in elements, (server_type, expected, elements[:1500])
+        assert expected in elements, (server_type, expected, reported)
+        registered[server_type] = elements
+
+    # Results only: the model writes ten more rasters under intermediate/, and
+    # publishing those buried the results the run was actually for. Scoped to the
+    # results workspace -- the demo publishes its *inputs* to the same GeoServer,
+    # so bare names like eto appear in the listing either way.
+    for intermediate in ("clipped_lulc", "eto", "kc_raster", "depth_to_root"):
+        assert "results:%s" % intermediate not in registered["WCS"], intermediate
+
+    # The table is a genuine upload, not a pointer at where it already sat: it
+    # is fetchable from the file server it was registered against.
+    table = re.search(r"results/[A-Za-z0-9_]+\.csv", registered["CSV"]).group(0)
+    fetched = requests.get("%s/%s" % (os.environ.get(
+        "FILESERVER_URL", "http://localhost:8001"), table), timeout=60)
+    assert fetched.status_code == 200, fetched.status_code
+    assert fetched.text.splitlines()[0].count(",") >= 1, fetched.text[:200]
 
 
 def test_dashboard_wps_process_detail(registered_wps_server, dashboard_url):

--- a/tools/easyows.py
+++ b/tools/easyows.py
@@ -120,8 +120,15 @@ class Catalog:
     def publish_shp(self,
                     shp_path,
                     shp_name = None,
-                    gs_workspace = None):
-        "Publishes a Shapefile to a workspace"
+                    gs_workspace = None,
+                    overwrite = False):
+        """Publishes a Shapefile to a workspace
+
+        overwrite replaces a store of the same name; without it GeoServer
+        rejects the request outright ("There is already a store named ..."), so
+        publishing the same layer twice -- a model re-run, a reloaded demo --
+        silently produces nothing.
+        """
 
         if gs_workspace is None:
             gs_workspace = self.make_named_workspace()
@@ -142,14 +149,16 @@ class Catalog:
 
         return self.gs_cat.create_featurestore(shp_name,
                                                workspace = gs_workspace,
-                                               data = shapefile_plus_sidecars)
+                                               data = shapefile_plus_sidecars,
+                                               overwrite = overwrite)
 
 
     def publish_tif(self,
                     tif_path,
                     tif_name = None,
-                    gs_workspace = None):
-        "Publishes a GeoTIFF to a workspace"
+                    gs_workspace = None,
+                    overwrite = False):
+        "Publishes a GeoTIFF to a workspace. See publish_shp for overwrite."
 
         if gs_workspace is None:
             gs_workspace = self.make_named_workspace()
@@ -167,12 +176,14 @@ class Catalog:
                                                 path = tif_path,
                                                 workspace = self.gs_cat.get_workspace(gs_workspace),
                                                 layer_name = tif_name,
-                                                upload_data = True)
+                                                upload_data = True,
+                                                overwrite = overwrite)
 
     def publish_gpkg(self,
                      gpkg_path,
                      gpkg_name = None,
-                     gs_workspace = None):
+                     gs_workspace = None,
+                     overwrite = False):
         "Publishes a GeoPackage by translating it to a Shapefile with GDAL first"
 
         from osgeo import gdal
@@ -186,7 +197,7 @@ class Catalog:
         self.logger.debug("Translating %s to %s" % (gpkg_path, shp_path))
         gdal.VectorTranslate(shp_path, gpkg_path, format="ESRI Shapefile")
 
-        return self.publish_shp(shp_path, gpkg_name, gs_workspace)
+        return self.publish_shp(shp_path, gpkg_name, gs_workspace, overwrite)
 
     def layer_url(self,layer_name):
         template = self.gs_url + "/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=%s&outputFormat=SHAPE-ZIP"

--- a/tools/invest_outputs.py
+++ b/tools/invest_outputs.py
@@ -40,7 +40,27 @@ def output_is_expected(output, args):
         return True
 
 
-def anticipated_outputs(spec, args=None):
+# Top-level directories holding working files rather than results. Matching on
+# these rather than keeping only "output/" because most models put their results
+# at the top level of the workspace -- 17 of 26, carbon among them -- so an
+# allow-list of output/ would discard almost everything worth publishing.
+_INTERMEDIATE_DIRS = {"taskgraph_cache", "tmp"}
+
+
+def is_primary_output(output):
+    """Whether this output is a result rather than a working file.
+
+    Publishing every declared output means a single annual_water_yield run puts
+    36 layers on a server, most of them clipped inputs and convolution kernels.
+    """
+    parts = (getattr(output, "path", "") or "").split("/")
+    if len(parts) < 2:
+        return True  # top level: the model's own results
+    head = parts[0]
+    return not (head.startswith("intermediate") or head in _INTERMEDIATE_DIRS)
+
+
+def anticipated_outputs(spec, args=None, primary_only=False):
     """The file outputs a run with ``args`` is expected to produce.
 
     With args omitted this is every file output the model declares, which is
@@ -55,11 +75,13 @@ def anticipated_outputs(spec, args=None):
             continue
         if not output_is_expected(output, args):
             continue
+        if primary_only and not is_primary_output(output):
+            continue
         expected.append(output)
     return expected
 
 
-def resolved_output_paths(spec, workspace_dir, args=None):
+def resolved_output_paths(spec, workspace_dir, args=None, primary_only=False):
     """[(output, absolute path)] for the outputs a run is expected to produce.
 
     A list of pairs rather than a dict: spec.Output is a pydantic model carrying
@@ -91,7 +113,7 @@ def resolved_output_paths(spec, workspace_dir, args=None):
         logger.debug("No FileRegistry (%s); suffixing by hand", exc)
 
     resolved = []
-    for output in anticipated_outputs(spec, args):
+    for output in anticipated_outputs(spec, args, primary_only=primary_only):
         path = None
         if registry is not None and "[" not in (output.id or ""):
             try:

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -652,7 +652,8 @@ def anticipated_for_job(job):
     # Only the argument values matter for created_if and the suffix, so the
     # workspace is irrelevant here; names are taken from the resolved basenames.
     out = []
-    for output, resolved in resolved_output_paths(spec, "/anticipated", job.args):
+    for output, resolved in resolved_output_paths(spec, "/anticipated", job.args,
+                                                 primary_only=True):
         lower = resolved.lower()
         if lower.endswith((".tif", ".tiff")):
             kind = "raster"

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -22,6 +22,7 @@ import importlib
 import logging
 import os
 import re
+import shutil
 import sys
 import tempfile
 
@@ -55,6 +56,37 @@ _WRAPPER_ARGS = {UPLOAD_FLAG} | set(DESTINATION_INPUTS.values())
 # than per-job so registered layer names are predictable; results_suffix is what
 # keeps successive runs apart.
 _RESULTS_WORKSPACE = os.environ.get("WPS_RESULTS_WORKSPACE", "results")
+
+# Where table outputs are uploaded to. A plain file server has no upload
+# protocol, so "uploading" a CSV means writing it into a directory that server
+# already publishes -- a volume shared between this container and the file
+# server. Unset means no writable share is configured, in which case tables are
+# reported where the WPS itself serves them from.
+_TABLE_UPLOAD_DIR = os.environ.get("WPS_TABLE_UPLOAD_DIR", "")
+# Path under the destination server that _TABLE_UPLOAD_DIR appears at, used to
+# build the identifier handed back to the client. Matches how the demo registers
+# CSV elements: a server-root-relative path, not an absolute URL.
+_TABLE_UPLOAD_PATH = os.environ.get("WPS_TABLE_UPLOAD_PATH",
+                                    _RESULTS_WORKSPACE)
+
+
+def _upload_table(path):
+    """Copy a table output into the shared directory the file server publishes.
+
+    Returns the destination-relative identifier, or None if no writable share is
+    configured or the copy fails -- the caller then falls back to reporting the
+    table where the WPS serves it.
+    """
+    if not _TABLE_UPLOAD_DIR:
+        return None
+    name = os.path.basename(path)
+    try:
+        os.makedirs(_TABLE_UPLOAD_DIR, exist_ok=True)
+        shutil.copyfile(path, os.path.join(_TABLE_UPLOAD_DIR, name))
+    except OSError as exc:
+        logger.warning("Could not upload table %s: %s", name, exc)
+        return None
+    return "%s/%s" % (_TABLE_UPLOAD_PATH.strip("/"), name)
 
 
 def _upload_inputs():
@@ -299,7 +331,8 @@ class InvestProcess(pywps.Process):
         easyows.Job.run.
         """
         uploads = {}
-        for output, path in resolved_output_paths(spec, workspace_dir, args):
+        for output, path in resolved_output_paths(spec, workspace_dir, args,
+                                                  primary_only=True):
             filename = output.path
             lower = filename.lower()
             is_raster = isinstance(output, (invest_spec.SingleBandRasterOutput,
@@ -372,7 +405,8 @@ class InvestProcess(pywps.Process):
                                    base, str(exc)[:200])
             return catalogs[base]
 
-        for output, path in resolved_output_paths(spec, args["workspace_dir"], args):
+        for output, path in resolved_output_paths(spec, args["workspace_dir"], args,
+                                                  primary_only=True):
             if not os.path.isfile(path):
                 continue
             lower = path.lower()
@@ -392,19 +426,28 @@ class InvestProcess(pywps.Process):
             name = re.sub(r"[^0-9A-Za-z]+", "_",
                           os.path.splitext(os.path.basename(path))[0]).strip("_")
             if kind == "table":
-                # There is no upload protocol for a plain file server, so a table
-                # is offered where it already is: the WPS serves its own outputs.
-                uploaded.append("table:%s" % os.path.basename(path))
+                # A file server has no upload protocol, so the table is copied
+                # into a directory it already publishes. Without that share it is
+                # offered where it already is: the WPS serves its own outputs.
+                uploaded.append("table:%s" % (_upload_table(path)
+                                              or os.path.basename(path)))
                 continue
 
             try:
                 cat = catalog_for(base)
+                # overwrite: the results workspace is stable and layer names come
+                # from the output filename, so re-running a model publishes the
+                # same names again. Without it GeoServer refuses the store and the
+                # run's results never reach the destination.
                 if kind == "raster":
-                    cat.publish_tif(path, name, _RESULTS_WORKSPACE)
+                    cat.publish_tif(path, name, _RESULTS_WORKSPACE,
+                                    overwrite=True)
                 elif lower.endswith(".gpkg"):
-                    cat.publish_gpkg(path, name, _RESULTS_WORKSPACE)
+                    cat.publish_gpkg(path, name, _RESULTS_WORKSPACE,
+                                     overwrite=True)
                 else:
-                    cat.publish_shp(path, name, _RESULTS_WORKSPACE)
+                    cat.publish_shp(path, name, _RESULTS_WORKSPACE,
+                                    overwrite=True)
             except Exception as exc:  # noqa: BLE001 - report the rest regardless
                 logger.warning("Could not publish %s to %s: %s",
                                name, base, str(exc)[:200])


### PR DESCRIPTION
Three related fixes to what a run's outputs do once the model finishes.

## Results only
A run declared every file the model writes, so publishing put 36 layers on the destination for `annual_water_yield` — clipped inputs, convolution kernels and taskgraph state buried the five layers the run was actually for.

Outputs are now filtered to results before publishing: **570 declared outputs across the 26 models become 164**; `annual_water_yield` goes from 28 to 7.

The filter is exclusion-based (drop `intermediate*`, `taskgraph_cache`, `tmp`) rather than keeping only `output/`, because **17 of the 26 models — carbon among them — write their results at the top level of the workspace**, so an allow-list would discard nearly everything worth publishing.

DescribeProcess and the per-output references still cover everything the model emits, so an intermediate stays fetchable by URL — it just is not pushed to a server.

## Table uploads are real uploads
A plain file server has no upload protocol, so `destination_http` used to report tables where they already sat. `wps` and `fileserver` now share a writable volume that the file server publishes at `/results/`, and a table output is copied into it — an upload the client can then fetch, which is what picking an HTTP destination implied all along.

## Republishing
GeoServer rejects a store that already exists, so **re-running a model published nothing at all**: layer names come from the output filenames and the results workspace is stable, so every second run collided with the first (`There is already a store named fractp_gura in workspace results`). `easyows.publish_*` now takes `overwrite`, and the results upload passes it.

This is also what made the round-trip test flaky: `smoke.sh` does not tear down at the *start*, so a run that inherited a populated `results` workspace failed while one against an empty workspace passed.

## Verification
- `make smoke-demo` (new target — runs the suite with the demo loaded so the round trip stops skipping): **22 passed**, including against an already-populated `results` workspace, the condition that used to fail.
- The `results` workspace after a run holds exactly `aet_gura`, `fractp_gura`, `wyield_gura` plus 2 vector stores — 3 rasters instead of 13.
- Both uploaded CSVs are served: `http://localhost:8001/results/watershed_results_wyield_gura.csv`.
- The round-trip test now asserts no `results:` intermediates are registered, and fetches the uploaded table over HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG