### PR TITLE
Declare each process's licences and user guide (closes #9)

### DIFF
--- a/tests/test_wps_capabilities.py
+++ b/tests/test_wps_capabilities.py
@@ -169,3 +169,33 @@ def test_echo_execute_roundtrips(wps_url):
     }, timeout=30)
     assert resp.status_code == 200, resp.text[:500]
     assert "hello-esws" in resp.text
+
+
+def test_every_invest_process_declares_a_licence_and_its_manual(wps_url):
+    """A process is someone else's model behind this wrapper, so both licences
+    have to be discoverable from the service itself.
+
+    WPS 1.0 has no licence field; ows:Metadata carrying the OGC licence role is
+    the standard place for it. Checked through DescribeProcess for all models at
+    once so a newly wrapped model cannot ship without one.
+    """
+    from natcap.invest import models
+
+    ids = sorted(models.model_id_to_pyname)
+    resp = requests.get(wps_url, params={
+        "service": "WPS", "version": "1.0.0", "request": "DescribeProcess",
+        "identifier": ",".join(ids)}, timeout=180)
+    assert resp.status_code == 200, resp.text[:1000]
+
+    descriptions = re.findall(r"<ProcessDescription.*?</ProcessDescription>",
+                              resp.text, re.S)
+    assert len(descriptions) == len(ids), (len(descriptions), len(ids))
+
+    missing = []
+    for description in descriptions:
+        identifier = re.search(r"<ows:Identifier>([^<]+)", description).group(1)
+        roles = re.findall(r'xlink:role="urn:ogc:def:role:OGC:1\.0:(\w+)"',
+                           description)
+        if roles.count("license") < 2 or "documentation" not in roles:
+            missing.append("%s -> %s" % (identifier, roles))
+    assert not missing, missing

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_describe_process.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_describe_process.html
@@ -10,6 +10,15 @@
         <p><b>Id</b></p><p>{{ process_id}}</p>
         <p><b>Title</b></p><p>{{ process_title}}</p>
         <p><b>Abstract</b></p><p>{{ process_abstract}}</p>        
+        {% if process_metadata %}
+        <p><b>Licence and documentation</b></p>
+        <table border=1 frame=void rules=all>
+        <tr><td>Role</td><td>Title</td><td>Link</td></tr>
+        {% for title,url,role in process_metadata %}
+        <tr><td>{{role}}</td><td>{{title}}</td><td><a href="{{url}}">{{url}}</a></td></tr>
+        {% endfor %}
+        </table>
+        {% endif %}
         <p><b>Inputs</b></p>
         <table border=1 frame=void rules=all>
         <tr><td>Id</td><td>Title<td width="50%">Abstract</td><td>Data Type</td><td>Min Occurs</td><td>Max Occurs</td></tr>

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -456,10 +456,16 @@ def server_wps_element_detail(request, server_pk, element_id):
         process_output.append(parameter_details)
     
     
+    # ows:Metadata the process declares -- its licences and its user guide. owslib
+    # names the link `url`, not `href`.
+    process_metadata = [(m.title, m.url, (m.role or "").rsplit(":", 1)[-1])
+                        for m in getattr(process, "metadata", None) or []]
+
     return render(request, 'wpsclient/server_wps_describe_process.html', {'server': server,
                                                                       'process_id': element_id,
                                                                       'process_title' : process.title,
                                                                       'process_abstract' : process.abstract,
+                                                                      'process_metadata' : process_metadata,
                                                                       'process_input' : process_input,
                                                                       'process_output' : process_output,
                                                                       'xml': description})    

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 
 import pywps
+from pywps.app.Common import Metadata
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 import easyows
@@ -87,6 +88,41 @@ def _upload_table(path):
         logger.warning("Could not upload table %s: %s", name, exc)
         return None
     return "%s/%s" % (_TABLE_UPLOAD_PATH.strip("/"), name)
+
+
+# Licensing. A process runs someone else's model through this wrapper, so both
+# licences apply and a client cannot infer either from the response: the wrapper
+# is MIT (see LICENSE), the models are InVEST's Apache-2.0.
+_LICENSES = (
+    ("MIT (ESWS WPS wrapper)",
+     "https://github.com/mlacayoemery/esws/blob/master/LICENSE"),
+    ("Apache-2.0 (InVEST model implementation)",
+     "https://github.com/natcap/invest/blob/main/LICENSE.txt"),
+)
+# The user guide is published per-language under /latest/ only -- there is no
+# version-pinned path, so a 3.20.0 process still documents itself from latest.
+_USERGUIDE_BASE = os.environ.get(
+    "INVEST_USERGUIDE_BASE",
+    "https://storage.googleapis.com/releases.naturalcapitalproject.org"
+    "/invest-userguide/latest/en")
+
+
+def _process_metadata(spec):
+    """ows:Metadata for a process: what it may be used under, and its manual.
+
+    WPS 1.0 has no licence field, and ows:Metadata is the only place in a
+    ProcessDescription for a typed external reference, so licences are carried as
+    links with role set to the OGC licence URN.
+    """
+    metadata = [Metadata(title, href=href,
+                               role="urn:ogc:def:role:OGC:1.0:license")
+                for title, href in _LICENSES]
+    userguide = getattr(spec, "userguide", None)
+    if userguide:
+        metadata.append(Metadata(
+            "User guide", href="%s/%s" % (_USERGUIDE_BASE, userguide),
+            role="urn:ogc:def:role:OGC:1.0:documentation"))
+    return metadata
 
 
 def _upload_inputs():
@@ -302,6 +338,7 @@ class InvestProcess(pywps.Process):
             version=natcap.invest.__version__,
             inputs=inputs,
             outputs=outputs,
+            metadata=_process_metadata(spec),
             store_supported=True,
             status_supported=True,
         )


### PR DESCRIPTION
Closes #9.

A process runs an InVEST model through this wrapper, so **two** licences apply, and a client could infer neither from the service: the wrapper is MIT, the models are InVEST's Apache-2.0.

WPS 1.0 has no licence field, so both ride as `ows:Metadata` with `role="urn:ogc:def:role:OGC:1.0:license"` — the standard place in a `ProcessDescription` for a typed external reference. The model's own manual comes along as a third entry with the `documentation` role, built from `MODEL_SPEC.userguide`.

```xml
<ows:Metadata xlink:title="MIT (ESWS WPS wrapper)"
  xlink:href="https://github.com/mlacayoemery/esws/blob/master/LICENSE"
  xlink:role="urn:ogc:def:role:OGC:1.0:license" />
<ows:Metadata xlink:title="Apache-2.0 (InVEST model implementation)"
  xlink:href="https://github.com/natcap/invest/blob/main/LICENSE.txt"
  xlink:role="urn:ogc:def:role:OGC:1.0:license" />
<ows:Metadata xlink:title="User guide"
  xlink:href=".../invest-userguide/latest/en/annual_water_yield.html"
  xlink:role="urn:ogc:def:role:OGC:1.0:documentation" />
```

They appear in DescribeProcess **and** GetCapabilities (78 elements = 26 processes × 3), and the dashboard's process page lists them as a "Licence and documentation" table. Unlike *input* metadata — which pywps 4.6 drops, hence the existing abstract trailer — process-level metadata renders, and owslib parses it (as `.url`, not `.href`).

Notes:
- The user guide is only published under `/latest/`; there is no version-pinned path (`3.20.0` and `3.20` both 404), so a 3.20.0 process documents itself from latest. Overridable via `INVEST_USERGUIDE_BASE`.
- All 26 user-guide URLs were checked to return 200.

## Verification
- New test asserts every one of the 26 processes declares two licence links and a documentation link, so a newly wrapped model cannot ship without them.
- `make smoke-demo`: **23 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG