### PR TITLE
Publish each parameter's range and unit (closes #4)

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -324,3 +324,30 @@ def test_dashboard_wps_process_detail(registered_wps_server, dashboard_url):
                                                           registered_wps_server),
         timeout=120)
     assert r.status_code == 200, r.text[:1000]
+
+
+def test_generated_form_enforces_the_declared_range(registered_wps_server,
+                                                    dashboard_url):
+    """A value the model would reject is rejected by the form.
+
+    forest_carbon_edge_effect's conversion factor is a ratio, so 1.5 is out of
+    range; annual_water_yield's seasonality constant must exceed 0, so 0 is too.
+    Both bounds come from the WPS, not from anything hard-coded here.
+    """
+    ratio = requests.get("%s/server/%d/execute/forest_carbon_edge_effect/"
+                         % (dashboard_url, registered_wps_server), timeout=120)
+    assert ratio.status_code == 200, ratio.text[:1000]
+    field = re.search(r'<input[^>]*name="biomass_to_carbon_conversion_factor"[^>]*>',
+                      ratio.text)
+    assert field, ratio.text[:2000]
+    assert 'min="0.0"' in field.group(0), field.group(0)
+    assert 'max="1.0"' in field.group(0), field.group(0)
+
+    # An exclusive bound has no HTML equivalent, so it is nudged one step: the
+    # smallest accepted value is just above 0, not 0 itself.
+    exclusive = requests.get("%s/server/%d/execute/annual_water_yield/"
+                             % (dashboard_url, registered_wps_server), timeout=120)
+    field = re.search(r'<input[^>]*name="seasonality_constant"[^>]*>',
+                      exclusive.text)
+    assert field, exclusive.text[:2000]
+    assert 'min="1e-09"' in field.group(0), field.group(0)

--- a/tests/test_wps_capabilities.py
+++ b/tests/test_wps_capabilities.py
@@ -199,3 +199,48 @@ def test_every_invest_process_declares_a_licence_and_its_manual(wps_url):
         if roles.count("license") < 2 or "documentation" not in roles:
             missing.append("%s -> %s" % (identifier, roles))
     assert not missing, missing
+
+
+def test_numeric_inputs_publish_their_declared_range(wps_url):
+    """A model's own bounds have to reach the client.
+
+    MODEL_SPEC states them as expressions over `value` ("value > 0",
+    "2012 <= value <= 2017") and as types that imply bounds (a ratio is 0 to 1).
+    Two-sided bounds go out as ows:AllowedValues/ows:Range; one-sided ones ride
+    the abstract trailer, because pywps 4.6 renders ows:MaximumValue
+    unconditionally and a half-open range would emit the string "None".
+    """
+    resp = requests.get(wps_url, params={
+        "service": "WPS", "version": "1.0.0", "request": "DescribeProcess",
+        "identifier": "annual_water_yield,forest_carbon_edge_effect,recreation,"
+                      "urban_mental_health"}, timeout=180)
+    assert resp.status_code == 200, resp.text[:1000]
+    assert ">None<" not in resp.text, "unset bound leaked into the response"
+
+    inputs = {}
+    for block in re.findall(r"<Input [^>]*>.*?</Input>", resp.text, re.S):
+        identifier = re.search(r"<ows:Identifier>([^<]+)", block).group(1)
+        inputs.setdefault(identifier, block)
+
+    # Two-sided: a ratio, bounded by its type rather than any expression.
+    ratio = inputs["biomass_to_carbon_conversion_factor"]
+    assert "<ows:MinimumValue>0.0</ows:MinimumValue>" in ratio, ratio
+    assert "<ows:MaximumValue>1.0</ows:MaximumValue>" in ratio, ratio
+
+    # Two-sided from a chained expression, on an integer input: the bounds must
+    # come out as integers rather than 2012.0.
+    year = inputs["start_year"]
+    assert "<ows:MinimumValue>2012</ows:MinimumValue>" in year, year
+    assert "<ows:MaximumValue>2017</ows:MaximumValue>" in year, year
+
+    # Mixed strictness: "value > 0 and value <= 1" excludes only the lower end.
+    effect = inputs["effect_size"]
+    assert 'ows:rangeClosure="open-closed"' in effect, effect
+    assert "<ows:MinimumValue>0.0</ows:MinimumValue>" in effect, effect
+    assert "<ows:MaximumValue>1.0</ows:MaximumValue>" in effect, effect
+
+    # One-sided and strict: "value > 0" excludes 0, which the trailer must say.
+    seasonality = inputs["seasonality_constant"]
+    assert "invest:min=0.0" in seasonality, seasonality
+    assert "invest:exclusive=open" in seasonality, seasonality
+    assert "invest:max" not in seasonality, seasonality

--- a/tools/wpsclient/wpsclient/forms.py
+++ b/tools/wpsclient/wpsclient/forms.py
@@ -113,6 +113,28 @@ def parse_input_metadata(parameter):
     return abstract, meta
 
 
+def _numeric_bounds(meta, cast):
+    """min_value/max_value for a numeric field, from the input's declared range.
+
+    The WPS publishes the model's own constraint -- a ratio is 0 to 1, a
+    seasonality constant must exceed 0 -- so the form can reject a value before a
+    job is submitted rather than after the model raises. An exclusive bound is
+    nudged by one step, which is the closest Django's validators can express.
+    """
+    bounds = {}
+    step = 1 if cast is int else 1e-9
+    closure = meta.get("exclusive", "closed")
+    if "min" in meta:
+        low = cast(float(meta["min"]))
+        bounds["min_value"] = (low + step if closure in ("open", "open-closed")
+                               else low)
+    if "max" in meta:
+        high = cast(float(meta["max"]))
+        bounds["max_value"] = (high - step if closure in ("open", "closed-open")
+                               else high)
+    return bounds
+
+
 class ProcessForm(forms.Form):
     """A form generated from a WPS DescribeProcess response.
 
@@ -190,9 +212,11 @@ class ProcessForm(forms.Form):
                     empty_label="---------", **common)
                 self.element_fields[identifier] = invest_type
             elif invest_type in ("number", "ratio", "percent"):
-                self.fields[identifier] = forms.FloatField(**common)
+                self.fields[identifier] = forms.FloatField(
+                    **_numeric_bounds(meta, float), **common)
             elif invest_type == "integer":
-                self.fields[identifier] = forms.IntegerField(**common)
+                self.fields[identifier] = forms.IntegerField(
+                    **_numeric_bounds(meta, int), **common)
             elif invest_type == "boolean" or parameter.dataType == "boolean":
                 common["required"] = False
                 self.fields[identifier] = forms.BooleanField(**common)

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -28,6 +28,8 @@ import tempfile
 
 import pywps
 from pywps.app.Common import Metadata
+from pywps.inout.basic import UOM
+from pywps.inout.literaltypes import ALLOWEDVALUETYPE, AllowedValue
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 import easyows
@@ -160,6 +162,99 @@ def _upload_inputs():
 _WORKSPACE_ROOT = os.environ.get("WPS_WORKSPACE_ROOT", tempfile.gettempdir())
 
 
+# A numeric constraint in MODEL_SPEC is a Python expression over `value`, e.g.
+# "value > 0" or "2012 <= value <= 2017". These cover every form InVEST 3.20 uses
+# except "float(value).is_integer()", which is a kind rather than a bound.
+_BOUND = re.compile(r"""^\s*(?:
+      value \s* (?P<vop>[<>]=?) \s* (?P<vnum>-?\d+(?:\.\d+)?)
+    | (?P<nnum>-?\d+(?:\.\d+)?) \s* (?P<nop>[<>]=?) \s* value
+    )\s*$""", re.X)
+_CHAIN = re.compile(r"""^\s* (?P<lo>-?\d+(?:\.\d+)?) \s* (?P<lop><=?) \s*
+                        value \s* (?P<uop><=?) \s* (?P<hi>-?\d+(?:\.\d+)?) \s*$""",
+                    re.X)
+# Ratio and percent carry their bounds in the type rather than an expression.
+_IMPLICIT_RANGES = {"ratio": (0.0, 1.0), "percent": (0.0, 100.0)}
+
+
+def _numeric_range(inp, arg_type):
+    """(minval, maxval, closure) for a numeric input, or None if unbounded.
+
+    closure is the WPS rangeClosure: whether each end is inclusive. InVEST writes
+    strict and non-strict comparisons both ("value > 0" vs "value >= 0"), and the
+    difference matters -- a seasonality constant of 0 is rejected by the model.
+    """
+    low = high = None
+    low_open = high_open = False
+
+    expression = getattr(inp, "expression", None) or ""
+    chained = _CHAIN.match(expression)
+    if chained:
+        low, high = float(chained.group("lo")), float(chained.group("hi"))
+        low_open = chained.group("lop") == "<"
+        high_open = chained.group("uop") == "<"
+    elif expression:
+        for clause in expression.split(" and "):
+            bound = _BOUND.match(clause)
+            if not bound:
+                continue
+            if bound.group("vop"):
+                op, number = bound.group("vop"), float(bound.group("vnum"))
+            else:
+                # "0 <= value" bounds value from below, so the operator flips.
+                op = {"<": ">", "<=": ">=", ">": "<", ">=": "<="}[bound.group("nop")]
+                number = float(bound.group("nnum"))
+            if op.startswith(">"):
+                low, low_open = number, op == ">"
+            else:
+                high, high_open = number, op == "<"
+
+    if low is None and high is None:
+        implicit = _IMPLICIT_RANGES.get(arg_type)
+        if not implicit:
+            return None
+        low, high = implicit
+
+    if arg_type == "integer":
+        # An integer input's bound is an integer: 2012, not 2012.0.
+        low = None if low is None else int(low)
+        high = None if high is None else int(high)
+
+    if low is None or high is None:
+        # Only one end is bounded, so the closure describes just that end:
+        # "value > 0" is an open lower bound with no upper bound at all.
+        closure = "open" if (low_open or high_open) else "closed"
+    else:
+        closure = {(False, False): "closed", (True, True): "open",
+                   (True, False): "open-closed",
+                   (False, True): "closed-open"}[(low_open, high_open)]
+    return low, high, closure
+
+
+def _numeric_kwargs(inp, arg_type):
+    """allowed_values and uoms for a numeric input, as far as MODEL_SPEC says.
+
+    A range lets a client validate before submitting instead of discovering the
+    bound in a model traceback, and the unit says what the number means -- "24
+    meter" and "24 hectare" are not the same input.
+    """
+    kwargs = {}
+    bounds = _numeric_range(inp, arg_type)
+    # Both ends or nothing: pywps 4.6 renders ows:MaximumValue unconditionally, so
+    # a half-open range comes out as <ows:MaximumValue>None</ows:MaximumValue>.
+    # One-sided bounds travel in the abstract trailer instead (see _literal_input),
+    # which is where this wrapper already puts what pywps cannot express.
+    if bounds and bounds[0] is not None and bounds[1] is not None:
+        low, high, closure = bounds
+        kwargs["allowed_values"] = [AllowedValue(
+            allowed_type=ALLOWEDVALUETYPE.RANGE,
+            minval=low, maxval=high, range_closure=closure)]
+    units = getattr(inp, "units", None)
+    # "none" is InVEST's dimensionless marker, not a unit worth advertising.
+    if units is not None and str(units) not in ("none", ""):
+        kwargs["uoms"] = [UOM(str(units))]
+    return kwargs
+
+
 def _literal_input(inp):
     """Map a single MODEL_SPEC input to a pywps LiteralInput.
 
@@ -190,6 +285,19 @@ def _literal_input(inp):
         trailer.append("invest:type=%s" % arg_type)
     if isinstance(required, str):
         trailer.append("invest:required=%s" % required)
+    # Numeric bounds go here as well as in ows:AllowedValues, because a half-open
+    # range cannot be expressed there (see _numeric_kwargs). A client gets every
+    # bound from the trailer, and standards-only clients get the two-sided ones
+    # from AllowedValues.
+    bounds = _numeric_range(inp, arg_type)
+    if bounds:
+        low, high, closure = bounds
+        if low is not None:
+            trailer.append("invest:min=%s" % low)
+        if high is not None:
+            trailer.append("invest:max=%s" % high)
+        if closure != "closed":
+            trailer.append("invest:exclusive=%s" % closure)
     if trailer:
         abstract = ("%s\n\n[%s]" % (abstract, " ".join(trailer))).strip()
 
@@ -202,9 +310,11 @@ def _literal_input(inp):
     )
 
     if arg_type in ("number", "ratio", "percent"):
-        return pywps.LiteralInput(data_type="float", **kwargs)
+        return pywps.LiteralInput(data_type="float",
+                                  **_numeric_kwargs(inp, arg_type), **kwargs)
     if arg_type == "integer":
-        return pywps.LiteralInput(data_type="integer", **kwargs)
+        return pywps.LiteralInput(data_type="integer",
+                                  **_numeric_kwargs(inp, arg_type), **kwargs)
     if arg_type == "boolean":
         return pywps.LiteralInput(data_type="boolean", **kwargs)
     if arg_type == "option_string":


### PR DESCRIPTION
Closes #4.

A model's numeric bounds were known but never left the server. `MODEL_SPEC` states them as expressions over `value` and as types that imply bounds:

| form | count | example |
|---|---|---|
| `value >= -1` | 26 | `n_workers` |
| `value > 0` | 25 | `seasonality_constant` |
| `value >= 0` | 9 | |
| `2012 <= value <= 2017` | 2 | `recreation.start_year` |
| `value > 0 and value <= 1` | 1 | `urban_mental_health.effect_size` |
| `0 <= value <= 100` | 1 | `urban_cooling_model.avg_rel_humidity` |
| implied by type | — | ratio → 0–1, percent → 0–100 |

**80 of the 101 numeric inputs** across the 26 models carry a bound, and until now a client could only discover it from a model traceback.

## What goes out
- **Two-sided** bounds as `ows:AllowedValues/ows:Range` with the correct `rangeClosure` — `value > 0 and value <= 1` is `open-closed`, and the distinction matters because the model rejects the excluded end. Integer inputs get integer bounds (`2012`, not `2012.0`).
- **One-sided** bounds via the abstract trailer (`[invest:type=number invest:min=0.0 invest:exclusive=open]`) rather than `ows:Range`: pywps 4.6 renders `ows:MaximumValue` unconditionally, so a half-open range emits `<ows:MaximumValue>None</ows:MaximumValue>`. This is the same pywps gap that already forced the `invest:type` trailer.
- **Units** as `ows:UOM` — "24 meter" and "24 hectare" are not the same input.

## Client side
The generated form applies the bounds as `min_value`/`max_value`, so a value the model would reject is rejected before the job is submitted. An exclusive bound has no HTML equivalent, so it is nudged one step (`min="1e-09"` for `value > 0`) — the closest Django's validators can express.

## Verification
- New WPS test covers a type-implied two-sided range, a chained integer range, mixed strictness (`open-closed`), a one-sided strict bound, and asserts no `None` leaks into the response.
- New dashboard test asserts the rendered inputs carry `min`/`max`.
- `make smoke-demo`: **25 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG