### PR TITLE
Add a per-run suffix flag so a rerun keeps the old results (closes #5)

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -203,17 +203,8 @@ def _pending_counts(session, dashboard_url, job_pk):
     return counts
 
 
-def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
-    """anticipated -> Local Pending -> published -> registered, for all three kinds.
-
-    Driven through the Templates source so the model arguments are InVEST's own
-    sample set: the form takes element ids, and picking an arbitrary option per
-    dropdown builds a job that is valid to Django and nonsense to InVEST, which
-    then rightly fails.
-
-    annual_water_yield rather than carbon because it emits rasters, vectors and
-    tables, so every destination kind is exercised in one run.
-    """
+def _demo_template_pk(dashboard_url):
+    """The pk of the demo Templates source, or None if the demo is not loaded."""
     templates = requests.get(dashboard_url + "/server/TPL/", timeout=30).text
     template_pk = None
     for row in re.findall(r"<tr>(.*?)</tr>", templates, re.S):
@@ -223,15 +214,23 @@ def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
         found = re.search(r"/server/TPL/(\d+)/element/", row)
         if found:
             template_pk = int(found.group(1))
-    if template_pk is None:
-        pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
+    return template_pk
 
-    session = requests.Session()
-    form_url = "%s/server/%d/execute/annual_water_yield/" % (dashboard_url, template_pk)
+
+def _submit_template_job(session, dashboard_url, template_pk, process_id,
+                         extra=None):
+    """Fill a template's job form with its own prefilled values and submit it.
+
+    Returns (job_pk, {destination field: server pk}). The prefilled values are
+    InVEST's sample arguments; picking an arbitrary option per dropdown instead
+    would build a job that is valid to Django and nonsense to InVEST.
+    """
+    form_url = "%s/server/%d/execute/%s/" % (dashboard_url, template_pk, process_id)
     page = session.get(form_url, timeout=180).text
     token = re.search(r'name="csrfmiddlewaretoken" value="([^"]+)"', page).group(1)
 
     data = {"csrfmiddlewaretoken": token, "upload_results": "on"}
+    data.update(extra or {})
     destinations = {}
     for match in re.finditer(r'<select name="([a-z_]+)"(.*?)</select>', page, re.S):
         name, body = match.group(1), match.group(2)
@@ -256,7 +255,40 @@ def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
     assert posted.status_code == 200, posted.text[:1000]
     job = re.search(r"/job/(\d+)/", posted.url)
     assert job, "form did not validate: %s" % posted.url
-    job_pk = int(job.group(1))
+    return int(job.group(1)), destinations
+
+
+def _await_job(session, dashboard_url, job_pk, tries=60):
+    """Poll a job to completion, returning the final status page."""
+    status = ""
+    for _ in range(tries):
+        status = session.get("%s/job/%d/status/" % (dashboard_url, job_pk),
+                             timeout=180).text
+        state = re.search(r"<b>Status: </b>([A-Za-z]+)", status)
+        if state and state.group(1) in ("Succeeded", "Failed"):
+            return state.group(1), status
+        time.sleep(4)
+    return None, status
+
+
+def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
+    """anticipated -> Local Pending -> published -> registered, for all three kinds.
+
+    Driven through the Templates source so the model arguments are InVEST's own
+    sample set: the form takes element ids, and picking an arbitrary option per
+    dropdown builds a job that is valid to Django and nonsense to InVEST, which
+    then rightly fails.
+
+    annual_water_yield rather than carbon because it emits rasters, vectors and
+    tables, so every destination kind is exercised in one run.
+    """
+    template_pk = _demo_template_pk(dashboard_url)
+    if template_pk is None:
+        pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
+
+    session = requests.Session()
+    job_pk, destinations = _submit_template_job(session, dashboard_url, template_pk,
+                                                "annual_water_yield")
 
     session.get("%s/job/%d/run/" % (dashboard_url, job_pk), timeout=180)
 
@@ -265,14 +297,8 @@ def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
     assert listed.get("WFS"), listed
     assert listed.get("CSV"), listed
 
-    for _ in range(60):
-        status = session.get("%s/job/%d/status/" % (dashboard_url, job_pk),
-                             timeout=180).text
-        state = re.search(r"<b>Status: </b>([A-Za-z]+)", status)
-        if state and state.group(1) in ("Succeeded", "Failed"):
-            break
-        time.sleep(4)
-    assert state and state.group(1) == "Succeeded", status[:2000]
+    state, status = _await_job(session, dashboard_url, job_pk)
+    assert state == "Succeeded", status[:2000]
 
     # Every pending entry for this job is gone...
     cleared = _pending_counts(session, dashboard_url, job_pk)
@@ -351,3 +377,49 @@ def test_generated_form_enforces_the_declared_range(registered_wps_server,
                       exclusive.text)
     assert field, exclusive.text[:2000]
     assert 'min="1e-09"' in field.group(0), field.group(0)
+
+
+def test_unique_run_does_not_overwrite_the_previous_runs_outputs(dashboard_url):
+    """Running a job twice with the flag set leaves both runs' results in place.
+
+    Output filenames -- and so the layer names they are published under -- derive
+    from results_suffix, so without a per-run token the second run republishes
+    over the first. With the flag, each run adds its own token and both sets of
+    layers survive.
+    """
+    template_pk = _demo_template_pk(dashboard_url)
+    if template_pk is None:
+        pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
+
+    session = requests.Session()
+    job_pk, destinations = _submit_template_job(
+        session, dashboard_url, template_pk, "annual_water_yield",
+        extra={"esws_unique_run": "on"})
+
+    detail = session.get("%s/job/%d/" % (dashboard_url, job_pk), timeout=60).text
+    assert "esws:unique_run" in detail, detail[:2000]
+
+    def wyield_layers():
+        elements = session.get("%s/server/WCS/%s/element/"
+                               % (dashboard_url, destinations["destination_wcs"]),
+                               timeout=120).text
+        return set(re.findall(r"results:(wyield_[A-Za-z0-9_]+)", elements))
+
+    # Measured as a delta: other tests publish to the same destination.
+    before = wyield_layers()
+    session.get("%s/job/%d/run/" % (dashboard_url, job_pk), timeout=180)
+    state, status = _await_job(session, dashboard_url, job_pk)
+    assert state == "Succeeded", status[:2000]
+    first = wyield_layers()
+    assert len(first - before) == 1, (before, first)
+
+    # "Run Again" is its own action: job_run on a finished job is the status poll.
+    assert "/job/%d/rerun/" % job_pk in session.get(
+        "%s/job/%d/" % (dashboard_url, job_pk), timeout=60).text
+    session.get("%s/job/%d/rerun/" % (dashboard_url, job_pk), timeout=180)
+    state, status = _await_job(session, dashboard_url, job_pk)
+    assert state == "Succeeded", status[:2000]
+
+    second = wyield_layers()
+    assert first < second, (first, second)
+    assert len(second - before) == 2, (before, second)

--- a/tools/wpsclient/wpsclient/forms.py
+++ b/tools/wpsclient/wpsclient/forms.py
@@ -94,6 +94,11 @@ class testForm(forms.Form):
 
 
 # Both the InVEST type trailer and the wrapper's own esws: trailer.
+# Name of the generated checkbox for the per-run suffix. Underscored rather than
+# namespaced with a colon, which is not valid in an HTML form field name; views
+# maps it onto the namespaced option it stores in Job.args.
+UNIQUE_RUN_FIELD = "esws_unique_run"
+
 _TRAILER = re.compile(r"\[(?:invest|esws):[^\]]*\]")
 _TRAILER_TOKEN = re.compile(r"(invest|esws):(\w+)=([^\s\]]+)")
 
@@ -225,6 +230,17 @@ class ProcessForm(forms.Form):
                 self.fields[identifier] = forms.ChoiceField(choices=choices, **common)
             else:
                 self.fields[identifier] = forms.CharField(**common)
+
+        # A client-side option rather than a WPS input: the dashboard turns it
+        # into a per-run results_suffix. Offered only where a suffix exists to
+        # extend, since that is what keeps one run's outputs apart from another's.
+        if "results_suffix" in self.fields:
+            self.fields[UNIQUE_RUN_FIELD] = forms.BooleanField(
+                label="Unique results for each run",
+                help_text="Add a short token to the results suffix on every run, "
+                          "so running this job again does not overwrite the "
+                          "outputs of the previous run.",
+                required=False)
 
 
 class JobDynamic(forms.ModelForm):

--- a/tools/wpsclient/wpsclient/templates/wpsclient/job_detail.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/job_detail.html
@@ -8,7 +8,14 @@
         <p><b>Server: </b><a href="{% url 'server_element_list' server_type='WPS' server_pk=job.server.pk %}">{{ job.server.title }}</a></p>
         <p><b>Process: </b><a href="{% url 'server_element_detail' server_type='WPS' server_pk=job.server.pk element_id=job.identifier %}">{{ job.identifier }}</a></p>        
         <p><b>Job Id: </b>{{job.pk}}<p/>
+        <p><b>Status: </b>{{job.status}}</p>
         <p><b><a href="{% url 'job_edit' job_pk=job.pk %}">Edit Job</a></b></p>
+        {% if can_rerun %}
+        <p><b><a href="{% url 'job_rerun' job_pk=job.pk %}">Run Again</a></b>
+        {% if unique_run %}&mdash; a fresh suffix, so this run will not overwrite
+        the last one's outputs{% else %}&mdash; will overwrite this run's outputs;
+        edit the job and tick "Unique results for each run" to keep them{% endif %}</p>
+        {% endif %}
         <table border=1 frame=void rules=all>
         <tr><td><b>key</b></td><td><b>value</b></td></tr>
         {% for k, v in job.args.items  %}

--- a/tools/wpsclient/wpsclient/urls.py
+++ b/tools/wpsclient/wpsclient/urls.py
@@ -47,5 +47,6 @@ urlpatterns = [
 ##    url(r'^test/(?P<server_pk>\d+)/execute/(?P<process_id>[a-zA-Z0-9_:]+)/$', views.job_new_wps, name='job_new_wps'),
     url(r'^test/wy/$', views.water_yield, name='water_yield'),
     url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/run/$', views.job_run, name='job_run'),
+    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/rerun/$', views.job_rerun, name='job_rerun'),
     url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/status/$', views.job_status, name='job_status'),    
 ]

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -25,6 +25,7 @@ from .forms import ServerFormWPS
 from .forms import ServerFormTemplate
 
 from .forms import ProcessForm
+from .forms import UNIQUE_RUN_FIELD
 
 from .forms import JobForm
 
@@ -485,7 +486,12 @@ def job_detail(request, job_pk):
     l.warning(inspect.stack()[0][3])    
     #detail of an existing process with parameters
     job = get_object_or_404(Job, pk=job_pk)
-    return render(request, 'wpsclient/job_detail.html', {'job': job})
+    return render(request, 'wpsclient/job_detail.html',
+                  {'job': job,
+                   # Only a finished job is worth resubmitting; while it is still
+                   # running, job_run is the poll.
+                   'can_rerun': job.status in _JOB_FINISHED,
+                   'unique_run': wants_unique_run(job)})
 
 ##def job_new(request, server_pk, process_id):
 ##    server = get_object_or_404(ServerWPS, pk=server_pk)
@@ -658,7 +664,8 @@ def anticipated_for_job(job):
     # Only the argument values matter for created_if and the suffix, so the
     # workspace is irrelevant here; names are taken from the resolved basenames.
     out = []
-    for output, resolved in resolved_output_paths(spec, "/anticipated", job.args,
+    for output, resolved in resolved_output_paths(spec, "/anticipated",
+                                                 effective_args(job),
                                                  primary_only=True):
         lower = resolved.lower()
         if lower.endswith((".tif", ".tiff")):
@@ -848,6 +855,12 @@ def job_new(request, server_pk, process_id):
         if form.is_valid():
             args = collections.OrderedDict()
             for name, value in form.cleaned_data.items():
+                if name == UNIQUE_RUN_FIELD:
+                    # Ours, not the WPS's: recorded under its namespaced key so
+                    # effective_args keeps it out of the Execute request.
+                    if value:
+                        args[UNIQUE_RUN_OPTION] = "true"
+                    continue
                 if value is None or value == "":
                     continue
                 if name in getattr(form, "destination_fields", {}):
@@ -967,6 +980,49 @@ def water_yield(request):
                     process_id="annual_water_yield")
 
 
+# Client-side job options live in job.args under this prefix. They are the
+# dashboard's own settings, not WPS inputs, and are stripped before submission --
+# kept in args because the wpsclient app has migrations disabled
+# (MIGRATION_MODULES) and so cannot gain a column without recreating the table.
+_OPTION_PREFIX = "esws:"
+UNIQUE_RUN_OPTION = _OPTION_PREFIX + "unique_run"
+RUN_TOKEN_OPTION = _OPTION_PREFIX + "run_token"
+
+
+def wants_unique_run(job):
+    return str(job.args.get(UNIQUE_RUN_OPTION, "")).lower() in ("true", "1", "yes")
+
+
+def rotate_run_token(job):
+    """Give this run its own results_suffix, so an earlier run's outputs survive.
+
+    Output filenames -- and therefore the layer names they are published under --
+    come from results_suffix, so without a per-run token a second run overwrites
+    the first. Eight hex digits is enough to keep runs apart while leaving the
+    names readable.
+    """
+    if not wants_unique_run(job):
+        return
+    job.args[RUN_TOKEN_OPTION] = uuid.uuid4().hex[:8]
+
+
+def effective_args(job):
+    """The WPS inputs for this run: job.args minus our options, plus the token.
+
+    Everything that derives names from the run -- the Execute URL, the anticipated
+    output list -- has to agree, so they all go through here rather than reading
+    job.args directly.
+    """
+    args = collections.OrderedDict(
+        (key, value) for key, value in job.args.items()
+        if not key.startswith(_OPTION_PREFIX))
+    token = job.args.get(RUN_TOKEN_OPTION)
+    if token:
+        base = args.get("results_suffix", "")
+        args["results_suffix"] = "%s_%s" % (base, token) if base else token
+    return args
+
+
 def job_to_wps_url(job, asynchronous=True):
     """The WPS Execute URL for a job.
 
@@ -975,8 +1031,9 @@ def job_to_wps_url(job, asynchronous=True):
     the whole run. Some InVEST models take minutes -- scenic_quality is around
     four -- and a synchronous request means the browser waits that long.
     """
+    args = effective_args(job)
     url = job.server.url + "?service=wps&version=1.0.0&request=Execute&IDENTIFIER=" + job.identifier + "&datainputs="
-    url = url + ";".join(["%s=%s" % (k, quote(quote(job.args[k]))) for k in job.args.keys()])
+    url = url + ";".join(["%s=%s" % (k, quote(quote(v))) for k, v in args.items()])
     if asynchronous:
         url += "&storeExecuteResponse=true&status=true&ResponseDocument=response"
 
@@ -1012,6 +1069,23 @@ def _wps_status(xml):
     """Read the ProcessX state out of an ExecuteResponse."""
     match = re.search(r"Process(Accepted|Started|Paused|Succeeded|Failed)", xml)
     return match.group(1) if match else ""
+
+
+def job_rerun(request, job_pk):
+    """Run a finished job again.
+
+    job_run deliberately will not resubmit a finished job -- that path is the
+    status poll -- so running twice is its own action. With the unique-results
+    option set, this run gets a fresh suffix and the previous run's outputs stay
+    where they are instead of being overwritten.
+    """
+    job = get_object_or_404(Job, pk=job_pk)
+    job.status = "Run"
+    job.status_location = ""
+    rotate_run_token(job)
+    job.save()
+
+    return redirect("job_run", job_pk=job.pk)
 
 
 def job_status(request, job_pk):
@@ -1066,6 +1140,7 @@ def job_run(request, job_pk):
 
     elif job.status == "Run":
         # Submit and return: the response carries a statusLocation, not results.
+        rotate_run_token(job)
         job.status_url = job_to_wps_url(job)
         try:
             with urllib.request.urlopen(job.status_url, timeout=120) as response:


### PR DESCRIPTION
Closes #5.

Output filenames — and so the GeoServer layer names they are published under — derive from `results_suffix`, so running a job twice republished **over** the first run's results. (That overwrite only started succeeding silently in #52; before it, the second run failed to publish at all.)

## The flag
"Unique results for each run" appears on the job form wherever the process has a `results_suffix` to extend — every InVEST model. When set, each submission adds eight hex digits to the suffix, so a second run publishes `wyield_gura_a1b2c3d4` **alongside** `wyield_gura`, not over it.

Everything that derives names from a run — the Execute URL, the anticipated-output list feeding "Local Pending" — goes through a single `effective_args()` so they agree on the suffix.

## Running twice
`job_run` on a finished job is the status poll, so it deliberately will not resubmit. Running again is now its own action: job detail grows a **Run Again** link that states whether the rerun will preserve or overwrite the current results.

## Why args, not columns
The flag and token live in `Job.args` under an `esws:` prefix and are stripped before submission. The `wpsclient` app has migrations disabled (`MIGRATION_MODULES = {'wpsclient': None}`) and its tables come from `migrate --run-syncdb`, which creates missing tables but cannot add a column to an existing one — a new field would break every running stack with `OperationalError` until its database was thrown away.

## Verification
New test runs `annual_water_yield` twice through the Templates form with the flag set and asserts the destination ends up with **two** `wyield_*` layers rather than one, measured as a delta since other tests publish to the same server. The round trip's form-driving code was extracted into `_submit_template_job`/`_await_job` and reused.

`make smoke-demo`: **26 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG