### PR TITLE
Make every model runnable on remote data: 12 of 24 → 22 of 24

### DIFF
--- a/missing_tmp.py
+++ b/missing_tmp.py
@@ -1,0 +1,12 @@
+import sys, os
+sys.path.insert(0, "/app/scripts")
+import run_model_jobs as R
+import invest_sample_manifest as manifest
+from load_demo import layer_name
+manifest.SAMPLES = R.SAMPLES
+entries, _ = manifest.build()
+files = manifest.build()  # (entries, unmatched)
+# which rasters does the manifest actually collect?
+collected = set()
+for mid, entry in entries[0].items() if isinstance(entries, tuple) else entries.items():
+    pass

--- a/scripts/load_demo.py
+++ b/scripts/load_demo.py
@@ -124,6 +124,10 @@ def publish(cat, files):
 
         name = layer_name(path)
         if name in existing:
+            # Already there, but still worth checking: a layer left disabled by
+            # an earlier load -- GeoServer could not resolve its CRS -- is
+            # repaired here rather than staying quietly unusable.
+            cat.ensure_srs(name, WORKSPACE, path)
             published[kind].append(name)
             continue
 
@@ -139,6 +143,11 @@ def publish(cat, files):
             continue
         published[kind].append(name)
         log("   + %-8s %s" % (kind, name))
+
+    unservable = getattr(cat, "unservable", [])
+    if unservable:
+        log("   %d layer(s) published but not servable (no identifiable CRS): %s"
+            % (len(unservable), ", ".join(sorted(unservable))))
 
     return published
 

--- a/tests/test_invest_tables.py
+++ b/tests/test_invest_tables.py
@@ -1,0 +1,199 @@
+"""Unit tests for the table-reference transport (tools/invest_tables.py).
+
+No stack and no InVEST needed: column specs are duck-typed and the download is
+injected, so the rewriting rules can be checked directly.
+"""
+import csv
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), "tools"))
+
+import invest_tables  # noqa: E402
+
+
+class Column:
+    """Stands in for a MODEL_SPEC column, which is inspected by id and type."""
+
+    def __init__(self, identifier, column_type, columns=None):
+        self.id = identifier
+        self.type = column_type
+        self.columns = columns
+
+
+def recording_fetch(available):
+    """A fetch that succeeds for the given URLs, recording what was asked for."""
+    asked = []
+
+    def fetch(url, destination):
+        asked.append(url)
+        if url not in available:
+            return False
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination, "w") as handle:
+            handle.write(available[url])
+        return True
+
+    fetch.asked = asked
+    return fetch
+
+
+def write_csv(path, rows):
+    with open(path, "w", newline="") as handle:
+        csv.writer(handle).writerows(rows)
+
+
+def read_csv(path):
+    with open(path, newline="") as handle:
+        return list(csv.reader(handle))
+
+
+def test_declared_column_is_fetched_and_rewritten(tmp_path):
+    table = tmp_path / "threats.csv"
+    write_csv(table, [["THREAT", "CUR_PATH"],
+                      ["crops", "crops_c.tif"],
+                      ["urban", "urban_c.tif"]])
+    base = "http://fileserver:8001/invest/HabitatQuality/threats.csv"
+    fetch = recording_fetch({
+        "http://fileserver:8001/invest/HabitatQuality/crops_c.tif": "raster",
+        "http://fileserver:8001/invest/HabitatQuality/urban_c.tif": "raster"})
+
+    count = invest_tables.localise_table(
+        str(table), base, [Column("cur_path", "raster")],
+        str(tmp_path / "refs"), fetch=fetch)
+
+    assert count == 2
+    rows = read_csv(table)
+    # The header is untouched and each value now points at a file that exists.
+    assert rows[0] == ["THREAT", "CUR_PATH"]
+    for row in rows[1:]:
+        assert os.path.isfile(row[1]), row
+
+
+def test_blank_cells_and_unknown_columns_are_left_alone(tmp_path):
+    table = tmp_path / "threats.csv"
+    write_csv(table, [["THREAT", "BASE_PATH", "CUR_PATH", "WEIGHT"],
+                      ["crops", "", "crops_c.tif", "0.7"]])
+    base = "http://host/data/threats.csv"
+    fetch = recording_fetch({"http://host/data/crops_c.tif": "raster"})
+
+    invest_tables.localise_table(str(table), base,
+                                 [Column("base_path", "raster"),
+                                  Column("cur_path", "raster")],
+                                 str(tmp_path / "refs"), fetch=fetch)
+
+    rows = read_csv(table)
+    assert rows[1][1] == "", rows          # blank stays blank
+    assert rows[1][3] == "0.7", rows       # a number is not a path
+    assert "http://host/data/" not in rows[1][3]
+
+
+def test_a_reference_that_cannot_be_fetched_keeps_its_original_value(tmp_path):
+    """The model's own error should name the value that is really missing."""
+    table = tmp_path / "threats.csv"
+    write_csv(table, [["CUR_PATH"], ["missing.tif"], ["present.tif"]])
+    base = "http://host/data/threats.csv"
+    fetch = recording_fetch({"http://host/data/present.tif": "raster"})
+
+    invest_tables.localise_table(str(table), base, [Column("cur_path", "raster")],
+                                 str(tmp_path / "refs"), fetch=fetch)
+
+    rows = read_csv(table)
+    assert rows[1][0] == "missing.tif", rows
+    assert os.path.isfile(rows[2][0]), rows
+
+
+def test_references_resolve_against_the_tables_own_url(tmp_path):
+    """A "../" reference is relative to the table on the server, not to /tmp."""
+    table = tmp_path / "biophysical.csv"
+    write_csv(table, [["PATH"], ["../Base_Data/dem.tif"]])
+    base = "http://host/invest/Model/biophysical.csv"
+    fetch = recording_fetch({"http://host/invest/Base_Data/dem.tif": "raster"})
+
+    count = invest_tables.localise_table(
+        str(table), base, [Column("path", "raster")], str(tmp_path / "refs"),
+        fetch=fetch)
+
+    assert count == 1, fetch.asked
+    assert os.path.isfile(read_csv(table)[1][0])
+
+
+def test_shapefile_companions_come_along(tmp_path):
+    table = tmp_path / "wave.csv"
+    write_csv(table, [["POINT_VECTOR"], ["points.shp"]])
+    base = "http://host/data/wave.csv"
+    fetch = recording_fetch({"http://host/data/points.shp": "shp",
+                             "http://host/data/points.shx": "shx",
+                             "http://host/data/points.dbf": "dbf",
+                             "http://host/data/points.prj": "prj"})
+
+    invest_tables.localise_table(str(table), base,
+                                 [Column("point_vector", "vector")],
+                                 str(tmp_path / "refs"), fetch=fetch)
+
+    local = read_csv(table)[1][0]
+    stem = os.path.splitext(local)[0]
+    for suffix in (".shp", ".shx", ".dbf", ".prj"):
+        assert os.path.isfile(stem + suffix), suffix
+
+
+def test_a_referenced_table_is_followed(tmp_path):
+    """crop production points at tables that point at rasters."""
+    inner = "CLIMATE_BIN,PATH\r\n1,yield.tif\r\n"
+    table = tmp_path / "outer.csv"
+    write_csv(table, [["CROP", "PATH"], ["abaca", "abaca.csv"]])
+    base = "http://host/data/outer.csv"
+    fetch = recording_fetch({"http://host/data/abaca.csv": inner,
+                             "http://host/data/yield.tif": "raster"})
+
+    count = invest_tables.localise_table(
+        str(table), base,
+        [Column("path", "csv", columns=[Column("path", "raster")])],
+        str(tmp_path / "refs"), fetch=fetch)
+
+    assert count == 2, fetch.asked
+    nested = read_csv(table)[1][1]
+    assert os.path.isfile(nested)
+    assert os.path.isfile(read_csv(nested)[1][1])
+
+
+def test_an_undeclared_cell_naming_a_raster_is_still_fetched(tmp_path):
+    """habitat risk assessment's criteria table: a number or a raster per cell."""
+    table = tmp_path / "criteria.csv"
+    write_csv(table, [["HABITAT", "eelgrass"],
+                      ["recruitment rate", "2"],
+                      ["connectivity rate", "layers/eelgrass_conn.tif"]])
+    base = "http://host/data/criteria.csv"
+    fetch = recording_fetch(
+        {"http://host/data/layers/eelgrass_conn.tif": "raster"})
+
+    count = invest_tables.localise_table(str(table), base, [],
+                                         str(tmp_path / "refs"), fetch=fetch)
+
+    assert count == 1, fetch.asked
+    rows = read_csv(table)
+    assert rows[1][1] == "2", rows
+    assert os.path.isfile(rows[2][1]), rows
+
+
+def test_localise_tables_only_touches_arguments_that_came_from_a_url(tmp_path):
+    class Spec:
+        inputs = [Column("from_url", "csv", columns=[Column("path", "raster")]),
+                  Column("local", "csv", columns=[Column("path", "raster")])]
+
+    remote = tmp_path / "remote.csv"
+    local = tmp_path / "local.csv"
+    for path in (remote, local):
+        write_csv(path, [["PATH"], ["data.tif"]])
+
+    fetch = recording_fetch({"http://host/data/data.tif": "raster"})
+    count = invest_tables.localise_tables(
+        Spec(), {"from_url": str(remote), "local": str(local)},
+        {"from_url": "http://host/data/remote.csv"}, str(tmp_path / "refs"),
+        fetch=fetch)
+
+    assert count == 1, fetch.asked
+    assert read_csv(local)[1][0] == "data.tif", "a local argument was rewritten"

--- a/tools/easyows.py
+++ b/tools/easyows.py
@@ -66,6 +66,11 @@ class Catalog:
 
         self.ows_cache = {}
 
+        # Layers published but left unservable because their CRS could not be
+        # identified. Kept so a bulk load can report the shortfall rather than
+        # claiming every layer it created is usable.
+        self.unservable = []
+
     @classmethod
     def from_env(cls, logger=logging.getLogger('easyows')):
         "Builds a Catalog from GEOSERVER_* environment variables (container config)"
@@ -147,10 +152,12 @@ class Catalog:
 ##        for feature in layer:
 ##            feature.GetGeomRef().GetEnvelope()
 
-        return self.gs_cat.create_featurestore(shp_name,
-                                               workspace = gs_workspace,
-                                               data = shapefile_plus_sidecars,
-                                               overwrite = overwrite)
+        created = self.gs_cat.create_featurestore(shp_name,
+                                                  workspace = gs_workspace,
+                                                  data = shapefile_plus_sidecars,
+                                                  overwrite = overwrite)
+        self.ensure_srs(shp_name, gs_workspace, shp_path)
+        return created
 
 
     def publish_tif(self,
@@ -172,12 +179,14 @@ class Catalog:
         # upload_data=True uploads the GeoTIFF to GeoServer over REST, so the
         # (separate) GeoServer container does not need filesystem access to the
         # WPS workspace.
-        return self.gs_cat.create_coveragestore(name = tif_name,
-                                                path = tif_path,
-                                                workspace = self.gs_cat.get_workspace(gs_workspace),
-                                                layer_name = tif_name,
-                                                upload_data = True,
-                                                overwrite = overwrite)
+        created = self.gs_cat.create_coveragestore(name = tif_name,
+                                                   path = tif_path,
+                                                   workspace = self.gs_cat.get_workspace(gs_workspace),
+                                                   layer_name = tif_name,
+                                                   upload_data = True,
+                                                   overwrite = overwrite)
+        self.ensure_srs(tif_name, gs_workspace, tif_path)
+        return created
 
     def publish_gpkg(self,
                      gpkg_path,
@@ -229,8 +238,101 @@ class Catalog:
         else:
             return re.search("coverageId=(.+)&", cover_url).group(1)
 
+    def ensure_srs(self, name, workspace, path):
+        """Declare a layer's CRS if GeoServer could not work it out itself.
+
+        A layer GeoServer publishes without an SRS is left disabled and answers
+        every request with "Could not locate coverage" / "defaultCRS should not be
+        null", so publishing appears to succeed and the layer is unusable. Returns
+        True if the layer is servable afterwards.
+        """
+        try:
+            resources = self.gs_cat.get_resources(stores=[name],
+                                                  workspaces=[workspace])
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug("Could not inspect %s: %s" % (name, exc))
+            return True
+
+        ok = True
+        for resource in resources or []:
+            if getattr(resource, "projection", None):
+                continue
+            epsg = identify_epsg(path, min_confidence=_CRS_MIN_CONFIDENCE,
+                                 logger=self.logger)
+            if not epsg:
+                self.logger.warning(
+                    "%s:%s has no CRS GeoServer recognises and none could be "
+                    "identified; the layer will not be served"
+                    % (workspace, resource.name))
+                self.unservable.append("%s:%s" % (workspace, resource.name))
+                ok = False
+                continue
+            resource.projection = epsg
+            # The file's own definition is the right one; FORCE_DECLARED just
+            # names it in terms GeoServer can use, without reprojecting.
+            resource.projection_policy = "FORCE_DECLARED"
+            resource.enabled = True
+            self.gs_cat.save(resource)
+            self.logger.info("Declared %s for %s:%s (CRS match threshold %d%%)"
+                             % (epsg, workspace, resource.name,
+                                _CRS_MIN_CONFIDENCE))
+        return ok
+
     def store_exists(self, name, workspace):
         return len(self.gs_cat.get_stores(names=name, workspaces=workspace)) > 0
+
+
+# How sure the CRS match has to be before a layer's SRS is declared for it.
+# Lowering this makes more sample data servable at the cost of accepting a guess:
+# two of the InVEST sample rasters carry an unnamed projection whose best matches
+# are three different UTM 21S datums at 70% apiece, and declaring one of them
+# would place the data tens of metres from where it belongs.
+_CRS_MIN_CONFIDENCE = int(os.environ.get("EASYOWS_CRS_MIN_CONFIDENCE", "90"))
+
+
+def identify_epsg(path, min_confidence=90, logger=logging.getLogger('easyows')):
+    """The EPSG code for a dataset's CRS, when it can be identified for certain.
+
+    GeoServer leaves a layer disabled -- and so unservable, "Could not locate
+    coverage", "defaultCRS should not be null" -- whenever it cannot resolve the
+    native CRS to an authority code. That happens for ESRI-style WKT names such as
+    RGF93_Lambert_93, for definitions tagged against a non-EPSG authority such as
+    IGNF:LAMB93, and for projections written without a datum.
+
+    pyproj does the matching rather than osr.FindMatches, which returns only the
+    authority a definition is already tagged with: it answers IGNF:LAMB93 for a
+    shapefile whose EPSG equivalent is plainly 2154.
+
+    Returns None rather than a guess below min_confidence. Declaring the wrong CRS
+    silently misplaces the data, which is worse than a layer that plainly does not
+    work -- two of the InVEST sample rasters carry an unnamed projection whose best
+    matches are three different UTM 21S datums at 70% apiece.
+    """
+    from osgeo import gdal
+    from pyproj import CRS
+
+    try:
+        dataset = gdal.OpenEx(path)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not open %s to identify its CRS: %s" % (path, exc))
+        return None
+    if dataset is None:
+        return None
+
+    srs = dataset.GetSpatialRef()
+    if srs is None and dataset.GetLayerCount():
+        # A vector carries its CRS on the layer, not on the dataset.
+        srs = dataset.GetLayer(0).GetSpatialRef()
+    if srs is None:
+        return None
+
+    try:
+        code = CRS.from_wkt(srs.ExportToWkt()).to_epsg(
+            min_confidence=min_confidence)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not match the CRS of %s: %s" % (path, exc))
+        return None
+    return "EPSG:%s" % code if code else None
 
 
 class Job:
@@ -241,9 +343,17 @@ class Job:
                  msg,
                  priority=0,                 
                  catalog = Catalog(),                 
-                 logger = logging.getLogger('easyows')):
+                 logger = logging.getLogger('easyows'),
+                 on_localised = None):
+        """on_localised(args, sources) runs once remote arguments are downloaded.
+
+        sources maps each argument to the URL it arrived as, which is what a
+        downloaded file's own internal references are relative to. Optional, and
+        errors in it are logged rather than raised.
+        """
 
         self.logger = logger
+        self.on_localised = on_localised
 
         logger.debug("Construting job with args %s" % str(args))
         
@@ -412,6 +522,12 @@ class Job:
 
         else:
             self.logger.debug("Downloading remote parameters")
+            # get_remote_parameters replaces each URL with the local path it was
+            # downloaded to, so the URLs have to be kept first: a downloaded file
+            # may need to know where it came from -- an InVEST table's references
+            # are relative to the table's own directory on the remote server.
+            sources = {key: value for key, value in self.args.items()
+                       if isinstance(value, str) and value[:4].lower() == "http"}
             try:
                 self.get_remote_parameters()
 
@@ -420,6 +536,13 @@ class Job:
 
             except IOError:
                 self.logger.debug("Could not download all remote parameters")
+
+            else:
+                if self.on_localised is not None:
+                    try:
+                        self.on_localised(self.args, sources)
+                    except Exception as exc:  # noqa: BLE001 - advisory only
+                        self.logger.warning("Post-download hook failed: %s", exc)
 
 
         return False

--- a/tools/invest_tables.py
+++ b/tools/invest_tables.py
@@ -1,0 +1,213 @@
+"""Bringing along the data an InVEST table points at.
+
+An InVEST table routinely names other files: a threats table lists a raster per
+threat, a snapshot table a raster per year, a wave table a vector per point set.
+Those names are paths relative to the table's own directory.
+
+When a job supplies such a table as an OWS/HTTP URL, the wrapper downloads the
+table alone, into a temporary file. Its references then resolve against that
+temporary directory and the model stops with
+
+    Error in column "cur_path", value "/tmp/crops_c.tif": File not found
+
+MODEL_SPEC says which columns hold paths, so this module fetches what those
+columns name -- relative to the URL the table itself came from -- and rewrites the
+table to point at the local copies.
+
+Some tables carry references the spec cannot describe: habitat risk assessment's
+criteria table holds either a number or a raster in the same cell, depending on
+the criterion. Cells that name a spatial file are therefore tried too, in any
+column; a value that is not a reference simply fails to fetch and is left alone.
+
+Kept free of pywps and natcap.invest so it can be exercised on its own; column
+specs are inspected through their ``type`` string rather than their class.
+"""
+import csv
+import hashlib
+import logging
+import os
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger("invest_tables")
+
+# Column types whose values name a file. "csv" is here too: a table may point at
+# further tables, which may themselves point at data (crop production does).
+PATH_COLUMN_TYPES = {"raster", "vector", "raster_or_vector", "file", "csv"}
+
+# Formats that are several files with a shared stem. Fetching only the .shp gives
+# GDAL a shapefile it cannot open, which reads as a missing file rather than an
+# incomplete one, so the companions are fetched too -- best effort, since which
+# ones exist varies.
+_SIDECARS = {
+    ".shp": (".shx", ".dbf", ".prj", ".cpg", ".qpj", ".sbn", ".sbx", ".shp.xml"),
+    # Raster attribute tables and world files sit beside the raster and are
+    # additive: a categorical raster keeps its categories in a .vat.dbf.
+    ".tif": (".tfw", ".tif.aux.xml", ".tif.vat.dbf", ".tif.vat.cpg", ".tif.ovr"),
+}
+_SIDECARS[".tiff"] = _SIDECARS[".tif"]
+
+# How deep to follow table-referencing-table. Two levels covers crop production
+# (a table of climate bins pointing at per-crop tables); the limit is a guard
+# against a cycle rather than a real constraint.
+_MAX_DEPTH = 3
+
+# Extensions worth trying in a column the spec does not type as a path. Narrow on
+# purpose: this is a guess, and a value that is not a reference must simply fail
+# to fetch rather than corrupt the table.
+_SPATIAL_EXTENSIONS = (".tif", ".tiff", ".shp", ".gpkg", ".vrt", ".img", ".asc")
+
+
+def _fetch(url, destination):
+    """Download url to destination, returning True on success."""
+    try:
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        urllib.request.urlretrieve(url, destination)
+        return True
+    except Exception as exc:  # noqa: BLE001 - a missing companion is not fatal
+        logger.debug("Could not fetch %s: %s", url, exc)
+        return False
+
+
+def _local_name(workdir, url):
+    """Where a referenced file goes locally.
+
+    One directory per referenced URL, named from a hash of it, with the file
+    keeping its own basename. A reference may be "../Base_Data/dem.tif" or may
+    collide with another column's file of the same name, and hashing sidesteps
+    both without having to reconstruct the remote directory tree. Companions land
+    in the same directory, so a shapefile's stem still resolves.
+    """
+    digest = hashlib.md5(url.encode("utf-8")).hexdigest()[:8]
+    return os.path.join(workdir, digest, os.path.basename(
+        urllib.parse.urlparse(url).path))
+
+
+def path_columns(column_specs):
+    """{lowercased column id: type} for the columns of a table that name files."""
+    columns = {}
+    for column in column_specs or []:
+        column_type = getattr(column, "type", "")
+        if column_type in PATH_COLUMN_TYPES and getattr(column, "id", None):
+            columns[column.id.lower()] = column_type
+    return columns
+
+
+def _column_spec(column_specs, column_id):
+    for column in column_specs or []:
+        if (getattr(column, "id", "") or "").lower() == column_id:
+            return column
+    return None
+
+
+def localise_table(local_path, source_url, column_specs, workdir,
+                   depth=0, fetch=_fetch):
+    """Fetch what a downloaded table references and repoint it at the copies.
+
+    ``local_path`` is the already-downloaded table, ``source_url`` the URL it came
+    from -- references resolve against that, not against the temporary file.
+    Rewrites ``local_path`` in place. Returns the number of files fetched.
+
+    A reference that cannot be fetched is left as it was: the model's own error
+    then names the value that is actually missing, which is more use than a path
+    into a temporary directory.
+    """
+    columns = path_columns(column_specs)
+    if depth >= _MAX_DEPTH:
+        return 0
+
+    try:
+        with open(local_path, newline="", encoding="utf-8-sig") as handle:
+            rows = list(csv.reader(handle))
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Could not read table %s: %s", local_path, exc)
+        return 0
+    if not rows:
+        return 0
+
+    header = rows[0]
+    # InVEST matches column names case-insensitively; the sample tables are
+    # upper case while the spec ids are lower.
+    targets = {index: columns[name.strip().lower()]
+               for index, name in enumerate(header)
+               if name.strip().lower() in columns}
+
+    fetched = 0
+    resolved = {}
+    for row in rows[1:]:
+        for index in range(len(row)):
+            column_type = targets.get(index)
+            reference = (row[index] or "").strip()
+            if not reference:
+                continue
+            if column_type is None:
+                # Not a column the spec types as a path, but some tables carry
+                # references the spec cannot describe: habitat risk assessment's
+                # criteria table holds either a number or a raster per cell. Only
+                # values that name a spatial file are tried, and a value that is
+                # not one simply fails to fetch and is left alone.
+                if not reference.lower().endswith(_SPATIAL_EXTENSIONS):
+                    continue
+                column_type = "file"
+
+            url = urllib.parse.urljoin(source_url, reference.replace("\\", "/"))
+            if url in resolved:
+                row[index] = resolved[url]
+                continue
+
+            destination = _local_name(workdir, url)
+            if not fetch(url, destination):
+                declared = index in targets
+                report = logger.warning if declared else logger.debug
+                report("Table %s references %s, which could not be fetched "
+                       "from %s", os.path.basename(local_path), reference, url)
+                continue
+            fetched += 1
+
+            # Companions are named from the stem, so the table lists ".tif.vat.dbf"
+            # rather than ".vat.dbf" and both forms build by simple concatenation.
+            stem, extension = os.path.splitext(urllib.parse.urlparse(url).path)
+            base = url[:len(url) - len(extension)]
+            for suffix in _SIDECARS.get(extension.lower(), ()):
+                companion = base + suffix
+                fetch(companion, os.path.join(os.path.dirname(destination),
+                                              os.path.basename(stem) + suffix))
+
+            if column_type == "csv" and index in targets:
+                # A referenced table may reference data of its own.
+                nested = _column_spec(column_specs, header[index].strip().lower())
+                fetched += localise_table(
+                    destination, url, getattr(nested, "columns", None),
+                    workdir, depth=depth + 1, fetch=fetch)
+
+            resolved[url] = destination
+            row[index] = destination
+
+    if not fetched:
+        return 0
+
+    with open(local_path, "w", newline="", encoding="utf-8") as handle:
+        csv.writer(handle).writerows(rows)
+    logger.info("Localised %d file(s) referenced by %s", fetched,
+                os.path.basename(local_path))
+    return fetched
+
+
+def localise_tables(spec, args, sources, workdir, fetch=_fetch):
+    """Localise every table argument that came from a URL.
+
+    ``sources`` maps argument id to the URL it was originally given as, which is
+    what the table's own references are relative to.
+    """
+    total = 0
+    for inp in spec.inputs:
+        source_url = sources.get(inp.id)
+        local_path = args.get(inp.id)
+        if not source_url or not local_path:
+            continue
+        if not str(local_path).lower().endswith(".csv"):
+            continue
+        total += localise_table(local_path, source_url,
+                               getattr(inp, "columns", None), workdir,
+                               fetch=fetch)
+    return total

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -35,6 +35,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 import easyows
 from invest_outputs import (anticipated_outputs, output_is_expected,
                             resolved_output_paths)
+from invest_tables import localise_tables
 
 import natcap.invest
 from natcap.invest import models
@@ -626,9 +627,15 @@ class InvestProcess(pywps.Process):
 
         uploads = self._build_uploads(ws, args["workspace_dir"], spec, args)
 
+        # An InVEST table can name other data files; when the table arrives as a
+        # URL those names have to be fetched too, or the model stops on a path
+        # into the download directory. See invest_tables.
+        references = tempfile.mkdtemp(prefix="esws-refs-", dir=_WORKSPACE_ROOT)
         job = easyows.Job(module.execute, args, uploads,
                           "InVEST %s WPS job %s" % (self.model_id, ws),
-                          0, cat, logger)
+                          0, cat, logger,
+                          on_localised=lambda job_args, sources: localise_tables(
+                              spec, job_args, sources, references))
 
         published = []
         ran = False


### PR DESCRIPTION
Submitting a job's inputs as OWS/HTTP URLs — what the generated form does when a user picks a registered source — worked for **half** the models. Two distinct causes, both silent until the model itself failed.

## 1. Tables that reference other data

An InVEST table routinely names further files: a threats table lists a raster per threat, a snapshot table a raster per year, a wave table a vector per point set. Those names are relative to **the table's own directory**, so downloading the table alone left them resolving against the download directory:

```
Error in column "cur_path", value "/tmp/crops_c.tif": File not found
```

`MODEL_SPEC` says which columns hold paths — 10 of the 26 models have them, including one column that is itself a table of tables — so the new `tools/invest_tables.py`:

- fetches what those columns name, resolved against the table's **source URL**;
- brings companions along (`.shx`/`.dbf`/`.prj`…, `.tif.vat.dbf`, `.tfw`);
- follows table→table to a depth of three (crop production needs two);
- rewrites the table to point at the local copies.

Habitat risk assessment's criteria table holds *either a number or a raster in the same cell*, which no column type can describe, so cells naming a spatial file are tried in any column. A value that is not a reference simply fails to fetch and is left as it was, so the model's own error still names what is really missing.

`easyows.Job` gained an `on_localised` hook for this — it replaces each URL with a local path, so the URLs must be captured before it runs.

## 2. Layers GeoServer would not serve

GeoServer leaves a layer **disabled** when it cannot resolve the native CRS to an authority code, then answers `Could not locate coverage` / `defaultCRS should not be null` — while publishing reports success. **Nine of the demo's 69 layers** were in that state.

`pyproj` identifies the CRS where GeoServer cannot, including definitions tagged against a non-EPSG authority (`IGNF:LAMB93` is plainly EPSG:2154, which `osr.FindMatches` will not say — it only ever returns the authority already on the definition). The layer is then declared and enabled with `FORCE_DECLARED`, which names the file's own CRS in terms GeoServer can use without reprojecting.

Matches below 90% are **refused rather than guessed**: two sample rasters match three different UTM 21S datums (MARGEN, SIRGAS 1995, SIRGAS 2000) at 70% apiece, and declaring one would place the data tens of metres off. `EASYOWS_CRS_MIN_CONFIDENCE` lowers the bar for anyone who accepts that trade.

`load_demo` now re-checks layers it skips — so a reload repairs anything an earlier load left disabled — and reports how many layers are published but unservable, instead of claiming all 69 are usable.

## Results

| mode | before | after |
|---|---|---|
| OWS/HTTP inputs | 12 of 24 | **22 of 24** |
| local paths | 24 of 24 | 24 of 24 |

Newly working: `coastal_blue_carbon`, `coastal_blue_carbon_preprocessor`, `coastal_vulnerability`, `crop_production_percentile`, `crop_production_regression`, `habitat_quality`, `habitat_risk_assessment`, `seasonal_water_yield`, `urban_nature_access`, `wave_energy`.

Still failing: `forest_carbon_edge_effect` and `scenario_generator_proximity`, whose sample AOI vectors carry a bare `Transverse_Mercator` with no datum that nothing can identify. The loader now names them rather than failing quietly.

## Verification
- `make smoke-demo`: **34 passed** — including 8 new unit tests for the transport that need neither the stack nor InVEST (injected fetch, duck-typed column specs), covering `../` references, companions, nested tables, undeclared cells, unfetchable references, and not touching local arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG