### PR TITLE
Take the dependency bumps that fit Python 3.11

### DIFF
--- a/docker/Dockerfile.invest
+++ b/docker/Dockerfile.invest
@@ -5,7 +5,7 @@
 # then pip-install the rest of the stack against that GDAL.
 #
 # Shared by the `wps` and `fileserver` compose services.
-FROM mambaorg/micromamba:1.5.8
+FROM mambaorg/micromamba:2.8.1
 
 # Install requirements file early for better layer caching.
 COPY --chown=$MAMBA_USER:$MAMBA_USER requirements/server.txt /tmp/server.txt

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -32,7 +32,10 @@ flask-cors
 geoserver-restconfig
 
 # --- Django dashboard (tools/wpsclient) ---
-Django==4.2.*
+# 4.2's extended support ended in April 2026; 5.2 is the current LTS, supported
+# to April 2028. Django 6.0 requires Python >= 3.12 and the image is on 3.11,
+# pinned by the InVEST conda environment, so 5.2 is as far as this can go.
+Django==5.2.*
 django-extensions
 owslib
 beautifulsoup4

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -15,13 +15,13 @@
 # against the conda-forge GDAL; 3.20.0 requires gdal==3.10.*, which is why the
 # Dockerfile pins that exact series.
 natcap.invest==3.20.0
-pygeoprocessing>=2.4.10
+pygeoprocessing>=2.4.11
 taskgraph[niced_processes]>=0.11.0
 pint
 Babel
 
 # --- WPS middleware ---
-pywps>=4.5,<4.7
+pywps>=4.7.0,<4.8
 Flask
 flask-cors
 


### PR DESCRIPTION
Works through the four remaining Dependabot pull requests, testing each against the running stack rather than merging on trust.

## Taken

**pygeoprocessing floor 2.4.10 → 2.4.11** (#63) and **pywps `<4.7` → `>=4.7.0,<4.8`** (#65). The upper bound on pywps existed because 4.7 was untested, not because it was known bad.

I checked one thing specifically before taking pywps 4.7: whether it renders `ows:MaximumValue` conditionally. It does not — the template is unchanged — so the abstract trailer carrying one-sided numeric bounds is still necessary, and nothing about #54 changes.

**micromamba base image 1.5.8 → 2.8.1** (#61). A major version of the image every service runs on; it builds and runs unchanged.

**Django 4.2 → 5.2 LTS** — instead of #64. 4.2's extended support **ended in April 2026**, so the dashboard was on an end-of-life Django; 5.2 is supported to April 2028. No code changes were needed: the earlier port to 4.2 had already removed everything 5.x drops (`re_path as url`, explicit `USE_TZ` and `DEFAULT_AUTO_FIELD`, no `timezone.utc` / `ugettext` / `force_text` / `render_to_response`).

## Refused

**Django 6.0** (#64) requires Python ≥ 3.12, and the image is on 3.11 — pinned by the InVEST conda environment. 5.2 requires only 3.10, which is why that is where this lands. Same shape of constraint as the Sphinx 9.1 refusal in #67.

## Verification

Committed one bump at a time so a failure could be bisected.

| check | result |
|---|---|
| image versions | python 3.11.15, pywps 4.7.0, pygeoprocessing 2.4.11, invest 3.20.0, gdal 3.10.3, django 5.2.16 |
| `make smoke-demo` (pywps/pygeoproc/micromamba) | 43 passed |
| full OWS model sweep | 22 of 24 — unchanged |
| `make smoke-demo` (Django 5.2) | 43 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG