### PR TITLE
Raise the taskgraph floor to 0.11.2

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -16,7 +16,7 @@
 # Dockerfile pins that exact series.
 natcap.invest==3.20.0
 pygeoprocessing>=2.4.11
-taskgraph[niced_processes]>=0.11.0
+taskgraph[niced_processes]>=0.11.2
 pint
 Babel
 


### PR DESCRIPTION
What the image already resolves to (verified: `taskgraph 0.11.2`), so this only stops an older one being installed.

Supersedes #68, which conflicted with the Django bump in #69 on the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG