### PR TITLE
Recognise datastacks by content, not filename

### DIFF
--- a/scripts/invest_sample_manifest.py
+++ b/scripts/invest_sample_manifest.py
@@ -35,9 +35,12 @@ def _datastacks():
     out = []
     for dirpath, _dirnames, filenames in os.walk(SAMPLES):
         for fn in filenames:
-            # Two naming conventions ship in the archives: the older
-            # <name>.invs.json and the newer <model>_datastack.invest.json.
-            if not (fn.endswith(".invs.json") or fn.endswith(".invest.json")):
+            # Recognised by content rather than name. At least three conventions
+            # ship in the archives -- <name>.invs.json,
+            # <model>_datastack.invest.json and invest_<model>_args.json -- and
+            # matching on the suffix missed the third, which is the only sample
+            # data urban_mental_health has.
+            if not fn.endswith(".json"):
                 continue
             path = os.path.join(dirpath, fn)
             try:
@@ -45,8 +48,12 @@ def _datastacks():
                     d = json.load(fh)
             except Exception:  # noqa: BLE001 - a bad datastack is just skipped
                 continue
+            if not isinstance(d, dict) or not isinstance(d.get("args"), dict):
+                continue
             pyname = d.get("model_name") or d.get("model_id") or ""
-            out.append((path, pyname, d.get("args") or {}))
+            if not pyname:
+                continue
+            out.append((path, pyname, d["args"]))
     return sorted(out)
 
 


### PR DESCRIPTION
`urban_mental_health` reported **"no sample args"** and was the one model never exercised, in either mode.

It does ship sample data — an AOI of census tracts, prevalence rates, NLCD baseline and alternate land cover, baseline and alternate NDVI, a population raster and an attribute table — under a **third** naming convention the matcher did not know:

| convention | recognised before |
|---|---|
| `<name>.invs.json` | yes |
| `<model>_datastack.invest.json` | yes |
| `invest_<model>_args.json` | **no** |

Matching on content instead of suffix — any JSON object carrying an `args` mapping and a model identifier — finds all three. Every one of the 26 models now has sample arguments, and `unmatched datastacks: 0`.

Worth saying plainly: I had started writing this model off as unrunnable without fabricating mental-health prevalence data and NDVI attributes, which would have been the wrong thing to ship in a demo. Checking the sample directory rather than trusting the report showed the data was already there.

## Results

| | before | after |
|---|---|---|
| local paths | 24 of 25 | **25 of 25** |
| OWS/HTTP | 22 of 25 | **23 of 25** |
| without sample data | 1 | **0** |
| demo publishes | 39 rasters / 30 vectors / 50 tables | 44 / 32 / 51 |

(`recreation` is excluded in both counts: it needs NatCap's remote recreation server. The two OWS failures remain `forest_carbon_edge_effect` and `scenario_generator_proximity`, whose sample AOI vectors carry no identifiable CRS.)

`make smoke-demo`: **56 passed** — including the change-detection test, whose assertion that exactly two rasters are unreachable still holds with five more rasters published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG