### PR TITLE
Declare pyproj, and stop the install checks going stale

### DIFF
--- a/docker/Dockerfile.baremetal-check
+++ b/docker/Dockerfile.baremetal-check
@@ -46,16 +46,27 @@ RUN "$HOME/.local/bin/micromamba" run -p "$HOME/esws-invest" \
         pip install --no-build-isolation -r requirements_py3.txt
 
 # --- assert the installed stack is the one the code needs -------------------
+#
+# Versions are read from requirements/server.txt rather than written out here.
+# They were hardcoded, and went stale the moment the stack moved to Django 5.2:
+# the check then failed on a correct install, which is the least useful way for a
+# check to fail. Comparing installed against declared still catches what matters
+# -- an install that did not honour its own pins.
+COPY --chown=esws:esws tools/crs_identify.py ./tools/crs_identify.py
 RUN "$HOME/.local/bin/micromamba" run -p "$HOME/esws-invest" python -c "\
-import natcap.invest, django, pywps, owslib, svgwrite, flask, bs4, geoserver.catalog; \
+import re, sys; \
+import natcap.invest, django, pywps, owslib, svgwrite, flask, bs4, geoserver.catalog, pyproj; \
+sys.path.insert(0, 'tools'); \
+import crs_identify; \
 from osgeo import gdal; \
 from natcap.invest import models; \
-print('invest', natcap.invest.__version__); \
-print('gdal', gdal.__version__); \
-print('django', django.get_version()); \
-print('models', len(models.model_id_to_pyname)); \
-assert natcap.invest.__version__ == '3.20.0', natcap.invest.__version__; \
-assert django.get_version().startswith('4.2'), django.get_version(); \
+pins = dict(re.findall(r'^([A-Za-z._-]+)==([0-9.]+)', open('requirements/server.txt').read(), re.M)); \
+print('pins', pins); \
+print('invest', natcap.invest.__version__, '| gdal', gdal.__version__, \
+      '| django', django.get_version(), '| pyproj', pyproj.__version__, \
+      '| models', len(models.model_id_to_pyname)); \
+assert natcap.invest.__version__ == pins['natcap.invest'], natcap.invest.__version__; \
+assert django.get_version().startswith(pins['Django'].rstrip('.')), django.get_version(); \
 assert gdal.__version__.startswith('3.10'), gdal.__version__; \
 assert len(models.model_id_to_pyname) == 26, len(models.model_id_to_pyname); \
 assert 'lulc_bas_path' in [i.id for i in models.model_id_to_spec['carbon'].inputs]; \

--- a/docker/Dockerfile.geoserver-check
+++ b/docker/Dockerfile.geoserver-check
@@ -17,9 +17,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /opt/esws
 COPY scripts/install-geoserver.sh scripts/install-geoserver.sh
+# The extra CRS definitions the script installs. Copied in so the check exercises
+# that step rather than skipping it -- the script guards on the file existing, so
+# without this it would quietly do nothing and still pass.
+COPY docker/geoserver/epsg.properties docker/geoserver/epsg.properties
 
 # install.sh option 7
 RUN sh scripts/install-geoserver.sh
+
+# The CRSs with no EPSG code have to reach a bare-metal install too, or the MODIS
+# sinusoidal layers are published disabled there while working in the container.
+RUN test -f /opt/geoserver_data/user_projections/epsg.properties \
+        || { echo "extra CRS definitions were not installed"; exit 1; }; \
+    grep -q '^996842=' /opt/geoserver_data/user_projections/epsg.properties \
+        || { echo "996842 (MODIS Sinusoidal) missing from user_projections"; exit 1; }
 
 # Boot it and assert it actually serves. A distribution that unpacked but cannot
 # run -- wrong Java, missing data dir -- would pass a file-existence check and

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -16,6 +16,12 @@
 # Dockerfile pins that exact series.
 natcap.invest==3.20.0
 pygeoprocessing>=2.4.11
+# tools/crs_identify.py depends on this directly: it is what recognises a CRS
+# GeoServer cannot name. It was only ever present by way of geopandas, which
+# natcap.invest pulls in and could stop pulling in -- and publishing breaks
+# quietly when it goes, because a layer with no identified CRS is published
+# disabled rather than refused.
+pyproj>=3.5
 taskgraph[niced_processes]>=0.11.2
 pint
 Babel

--- a/scripts/install-geoserver.sh
+++ b/scripts/install-geoserver.sh
@@ -58,6 +58,18 @@ else
     echo ">> Keeping existing data directory ${GEOSERVER_DATA_DIR}"
 fi
 
+# CRSs with no EPSG code -- the MODIS sinusoidal grid -- so a bare-metal
+# GeoServer can serve the same layers the container one can. Installed on every
+# run, not only when the data directory is seeded, so an existing install picks
+# it up too. Without it those layers are published disabled and every request
+# for them answers "Could not locate coverage".
+EXTRA_CRS="$(dirname "$0")/../docker/geoserver/epsg.properties"
+if [ -f "${EXTRA_CRS}" ]; then
+    echo ">> Installing extra CRS definitions"
+    $SUDO mkdir -p "${GEOSERVER_DATA_DIR}/user_projections"
+    $SUDO cp "${EXTRA_CRS}" "${GEOSERVER_DATA_DIR}/user_projections/epsg.properties"
+fi
+
 echo ">> GeoServer ${GS_VERSION} installed. Start it with:"
 echo "     GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR} ${GEOSERVER_HOME}/bin/startup.sh"
 echo "   or install the esws-geoserver systemd unit (install.sh option 8)."

--- a/tests/unit/test_crs_identification.py
+++ b/tests/unit/test_crs_identification.py
@@ -101,3 +101,32 @@ def test_a_resolvable_authority_is_left_alone(tmp_path):
     crs_identify.drop_unresolvable_authority(str(tmp_path),
                                         crs_identify.logging.getLogger("t"))
     assert prj.read_text() == original
+
+
+def test_the_shipped_geoserver_definitions_parse_and_are_what_they_claim():
+    """A typo in docker/geoserver/epsg.properties would not fail loudly.
+
+    GeoServer would decline the definition and go back to publishing those layers
+    disabled -- the state this file exists to fix -- so the file is checked here
+    rather than only in an integration run.
+    """
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__)))), "docker", "geoserver", "epsg.properties")
+    entries = {}
+    for line in open(path):
+        line = line.strip()
+        if line and not line.startswith("#"):
+            code, _, wkt = line.partition("=")
+            entries[code] = wkt
+
+    assert "996842" in entries, sorted(entries)
+    # Not 6842: that is NAD83(2011) / Oregon Coast zone, and this file extends the
+    # EPSG namespace, so registering it there is silently ignored in favour of the
+    # real definition.
+    assert "6842" not in entries, "6842 collides with an assigned EPSG code"
+
+    crs = CRS.from_wkt(entries["996842"])
+    assert "sinusoidal" in crs.coordinate_operation.method_name.lower()
+    assert crs.ellipsoid.semi_major_metre == 6371007.181
+    # The vendor table has to point at the code that is actually registered.
+    assert crs_identify._VENDOR_CRS[0]["code"] == "EPSG:996842"


### PR DESCRIPTION
Three things this session's work left exposed.

## pyproj was undeclared

`tools/crs_identify.py` imports it directly — it is what recognises a CRS GeoServer cannot name — but **nothing in the stack requires it**:

```
natcap.invest   -> does not require pyproj
pygeoprocessing -> does not require pyproj
packages requiring pyproj: geopandas, geotiff
```

It arrived by way of `geopandas`. Had that changed, publishing would have broken *quietly*, because a layer whose CRS goes unidentified is published **disabled** rather than refused — the exact failure mode #74 was about.

## check-baremetal had been failing since #69

```
assert django.get_version().startswith('4.2')
```

Broken the moment the stack moved to Django 5.2, and I did not notice because I did not re-run it after that bump. A check that fails on a *correct* install is the least useful way for a check to fail.

The version assertions now read from the pins in `requirements/server.txt`, so an install that honours its own pins passes and the next bump doesn't break the check:

```
pins {'natcap.invest': '3.20.0', 'Django': '5.2.'}
invest 3.20.0 | gdal 3.10.3 | django 5.2.16 | pyproj 3.7.2 | models 26
BARE-METAL INSTALL OK
```

It also imports `crs_identify` and `pyproj`, so the bare-metal path is checked to have what publishing needs.

## check-geoserver was passing without exercising its own step

`install-geoserver.sh` installs the extra CRS definitions behind a guard on the file existing — and the check image never copied that file in, so the step silently did nothing and the check passed anyway. It copies it now and asserts `996842` arrives. Otherwise a bare-metal GeoServer publishes the MODIS sinusoidal layers disabled while the container one serves them.

`install-geoserver.sh` also installs them on *every* run rather than only when seeding a fresh data directory, so an existing install picks them up.

## Plus a unit test for the definitions file

A typo in `docker/geoserver/epsg.properties` would not fail loudly — GeoServer would decline the definition and go back to disabling those layers. The test parses it, checks the WKT is sinusoidal on the right sphere, and pins that the code is `996842` and **not** `6842`.

## Verification
- `make smoke-demo`: **65 passed**
- `make check-baremetal`: passes (was failing)
- `make check-geoserver`: passes, now actually exercising the CRS step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG