### PR TITLE
Make the installer's sample-data option work

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ OPTIONS=(0 "Clone ESWS repository"
          7 "Install GeoServer"
          8 "Install systemd services"
          9 "Configure firewall"
-         10 "Install InVEST Data"
+         10 "Install InVEST sample data"
          Q "Quit setup")
 
 while true; do 
@@ -186,7 +186,24 @@ read -p "Press [Enter] key to continue..."
 ;;
 
 10)
-python tools/invest/import_sample_data_wy.py 
+# Fetch the InVEST sample datasets and publish them: rasters and vectors to
+# GeoServer, tables over HTTP, everything registered in the dashboard. The same
+# loader `make demo` runs, pointed at a local install rather than at the compose
+# network -- it takes every endpoint from the environment.
+#
+# It replaces tools/invest/import_sample_data_wy.py, which this option used to
+# run. That script is Python 2 and has been unable to even parse for as long as
+# this installer has targeted Python 3, so the option could only ever fail.
+ESWS_ENV="${ESWS_ENV:-$HOME/esws-invest}"
+./scripts/fetch_invest_samples.sh
+# The loader's endpoints default to the compose service names; on a local
+# install everything is on this host.
+DASHBOARD_URL="${DASHBOARD_URL:-http://localhost:8000}" \
+FILESERVER_URL="${FILESERVER_URL:-http://localhost:8001}" \
+WPS_URL="${WPS_URL:-http://localhost:5000/wps}" \
+GEOSERVER_BASE_URL="${GEOSERVER_BASE_URL:-http://localhost:8080/geoserver}" \
+INVEST_SAMPLES_DIR="${INVEST_SAMPLES_DIR:-${INVEST_DATA_ROOT:-/store/invest}/samples}" \
+    "$HOME/.local/bin/micromamba" run -p "$ESWS_ENV" python scripts/load_demo.py
 ;;
 
 Q)

--- a/tools/invest/README.md
+++ b/tools/invest/README.md
@@ -1,0 +1,21 @@
+# Pre-container scripts (not on any code path)
+
+Everything in this directory, and in `../swat`, predates the containerised stack
+and is **Python 2**. None of it parses under the Python 3 the project runs on:
+
+    $ python3 -c "import ast; ast.parse(open('import_sample_data_wy.py').read())"
+    SyntaxError: Missing parentheses in call to 'print'
+
+Nothing references it. `install.sh` option 10 used to run
+`import_sample_data_wy.py`, which meant that option could only ever fail; it now
+runs `scripts/load_demo.py`, the same loader `make demo` uses. CI excludes both
+directories from its byte-compile step for the same reason.
+
+Kept for reference — the modern equivalents are:
+
+| here | now |
+|---|---|
+| `import_sample_data*.py` | `scripts/load_demo.py` |
+| `simple_http_server.py` | `tools/http_server.py` |
+| `wps.py` | `tools/wpsserver/wpsprocess/invest_models.py` |
+| `gs_example.py`, `test_invest_sdr_demo.py` | `scripts/run_model_jobs.py` |


### PR DESCRIPTION
`install.sh` option 10, *"Install InVEST Data"*, ran `tools/invest/import_sample_data_wy.py`. That file is **Python 2** and does not parse under Python 3:

```
SyntaxError: Missing parentheses in call to 'print'
```

So the option could only ever fail, for as long as this installer has targeted Python 3.

It now fetches the sample archives and runs `scripts/load_demo.py` — the same loader `make demo` uses — with the endpoints defaulted to `localhost`, since the loader's own defaults are the compose service names.

## The dead tree

`tools/invest` and `tools/swat` are entirely pre-container Python 2, and once that line went, nothing referenced them at all. Rather than delete someone else's history, there's now a README recording what replaced what, so the next reader isn't left wondering why CI excludes them from its byte-compile step:

| there | now |
|---|---|
| `import_sample_data*.py` | `scripts/load_demo.py` |
| `simple_http_server.py` | `tools/http_server.py` |
| `wps.py` | `tools/wpsserver/wpsprocess/invest_models.py` |
| `gs_example.py`, `test_invest_sdr_demo.py` | `scripts/run_model_jobs.py` |

## Verification
- `make check-baremetal`: PASS
- `make check-geoserver`: PASS
- unit tests: 36 passed

Worth being explicit about the limit: **neither check exercises option 10** — they cover options 1, 2 and 4 — so this change is verified by inspection and `bash -n`, not by execution. Running it end to end needs a machine with the bare-metal stack actually installed and serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG