### PR TITLE
One workspace per run, not two

### DIFF
--- a/tools/easyows.py
+++ b/tools/easyows.py
@@ -120,7 +120,9 @@ class Catalog:
 
         if f is None:
             def f(s):
-                return s[:5] == self.ws_prefix
+                # startswith, not s[:5]: that hardcoded the length of "esws-"
+                # and silently matched nothing for any other prefix.
+                return s.startswith(self.ws_prefix)
 
         self.logger.debug("Cleaning workspace")
 

--- a/tools/wpsserver/wpsprocess/invest_models.py
+++ b/tools/wpsserver/wpsprocess/invest_models.py
@@ -493,7 +493,8 @@ class InvestProcess(pywps.Process):
             if not (is_raster or is_vector):
                 continue
             base = os.path.splitext(os.path.basename(path))[0]
-            layer = re.sub(r"[^0-9A-Za-z]+", "_", base).strip("_") or "layer"
+            # The same naming the upload path uses, so the two agree.
+            layer = results_layout.safe(base)
             uploads["%s:%s" % (ws, layer)] = path
         return uploads
 
@@ -648,7 +649,12 @@ class InvestProcess(pywps.Process):
             cat.clean_named_workspace()
         except Exception:  # noqa: BLE001
             raise pywps.exceptions.NoApplicableCode("Could not clean GeoServer workspace(s)")
-        ws = cat.make_named_workspace(str(self.uuid))
+        # The same workspace the upload path publishes into, so a run has one
+        # workspace rather than two. These are separate publishes for separate
+        # reasons -- this one makes the run viewable at all, the other keeps the
+        # results where the client asked -- but they are the same run's outputs,
+        # and giving them two differently named homes only made that harder to see.
+        ws = cat.make_workspace(results_layout.run_workspace(str(self.uuid)))
 
         uploads = self._build_uploads(ws, args["workspace_dir"], spec, args)
 


### PR DESCRIPTION
A run created **two** GeoServer workspaces.

`easyows.Job` published into `esws-<uuid>` so the run would be viewable at all — that's what the `response` output's WMS URLs point at — while the upload path published into `run_<uuid>` when the client asked for results to be kept.

Two publishes for two different reasons is fine. The same run's outputs under two names is not: it made the relationship between them invisible and doubled what a reader has to hold.

Both now use `results_layout.run_workspace`, and `_build_uploads` names its layers with `results_layout.safe`, so the two agree exactly. Publishing to a destination that happens to *be* the WPS's own GeoServer now lands **in** the run's workspace rather than beside it.

```
before:  run_* : 18   esws-* : 1
after :  run_* : 19   esws-* : []
```

The `response` output still carries its WMS URLs (verified: 3 for carbon), so the legacy path's purpose is intact.

## A latent bug found on the way

`clean_named_workspace` matched its prefix with `s[:5]` — the length of `"esws-"`. Any other prefix silently matched nothing, so the cleanup it offers quietly did nothing. `startswith` now.

## Verification
- `make verify`: **84 passed**
- `make check-layouts`: all four combinations ok, and no `esws-*` workspace is created any more

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKtuUqpdP81TzwuuwKH5dG