### PR TITLE
Track server.txt's Django pin in the dashboard subset

### DIFF
--- a/tools/wpsclient/requirements_py3.txt
+++ b/tools/wpsclient/requirements_py3.txt
@@ -5,5 +5,13 @@
 # anywhere under tools/wpsclient any more.
 #   jsonfield                    -> django.db.models.JSONField
 #   django-SplitJSONWidget-form  -> tools/wpsclient/wpsclient/widgets.py
-Django==4.2.*
+#
+# This pin must track ../../requirements/server.txt. It cannot defer to it with
+# -r: the point of this file is to be the dashboard-only subset, and server.txt
+# carries the whole InVEST geo stack. So it is a copy, and copies drift -- this
+# one sat at 4.2 while the stack moved to 5.2, which made the
+# "DASHBOARD SUBSET OK" step of docker/Dockerfile.baremetal-check meaningless:
+# it dry-run installs this file into the env built from server.txt, so a lower
+# pin resolves as a *downgrade* and still exits 0. Bump both together.
+Django==5.2.*
 owslib


### PR DESCRIPTION
`tools/wpsclient/requirements_py3.txt` pinned `Django==4.2.*` while
`requirements/server.txt` had moved to `Django==5.2.*`.

PR #41 made the *root* `requirements_py3.txt` defer to `server.txt` with `-r`
specifically so it could not drift from the container stack again. This
dashboard-only subset was missed, and drifted.

### Why it matters

It is not dead config. `docker/Dockerfile.baremetal-check` finishes with:

```dockerfile
RUN "$HOME/.local/bin/micromamba" run -p "$HOME/esws-invest" \
        pip install --dry-run -r tools/wpsclient/requirements_py3.txt \
    && echo "DASHBOARD SUBSET OK"
```

That dry-run resolves against the environment already built from `server.txt`,
which has Django 5.2 installed. With the lower pin, pip resolves it as a
**downgrade** to 4.2 — and succeeds. So the step exited 0 and printed
`DASHBOARD SUBSET OK` while actually asserting that 4.2 can be installed over
5.2, not that the subset resolves against the built stack. The check was
vacuous rather than failing, which is why it went unnoticed.

Django 4.2's extended support also ended in April 2026, as `server.txt`'s own
comment notes.

### Why the pin is copied rather than deferred

This file cannot use `-r ../../requirements/server.txt` the way the root file
does: its purpose is to be the *dashboard-only* subset, and `server.txt` carries
the whole InVEST geo stack. So it stays a copy, and copies drift — the added
comment says so explicitly and tells the next person to move both together.

### Verification

- `make unit` — 52 passed
- `make verify` on the parent commit (this branch's base) — 84 passed, 0 skipped,
  with demo data loaded
- **Not run:** `make check-baremetal`, which is what actually exercises the
  changed file. It builds InVEST from sdist and is slow, so it is deliberately
  outside `make smoke`. Worth running before merge to confirm the subset now
  resolves against the 5.2 stack with no downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi