### PR TITLE
Recompute bounds for a layer whose CRS we declared

### DIFF
--- a/tests/test_invest_smoke.py
+++ b/tests/test_invest_smoke.py
@@ -5,7 +5,9 @@ path: collect args -> module.execute() -> publish MODEL_SPEC outputs to GeoServe
 -> return WMS URL. Requires the geoserver service to be up.
 """
 import os
+import re
 
+import pytest
 import requests
 
 DATA_DIR = "/app/tests/data"
@@ -36,3 +38,41 @@ def test_carbon_executes_and_publishes(wps_url, geoserver_url):
     # (a publish failure would raise and surface as ProcessFailed).
     assert "ProcessSucceeded" in resp.text, resp.text[:3000]
     assert "wms" in resp.text.lower(), resp.text[:3000]
+
+
+def test_every_published_layer_is_advertised_by_wms(geoserver_url):
+    """A layer GeoServer will not advertise is a layer nobody can find.
+
+    A layer imported without a resolvable CRS gets no latLonBoundingBox, and
+    WMS 1.3.0 cannot emit a layer without an EX_GeographicBoundingBox -- so
+    GeoServer drops it from GetCapabilities while still serving it perfectly
+    over WFS and WCS. Publishing succeeds, every round-trip test passes, and
+    the layer is simply undiscoverable, which is how four of the demo's layers
+    stayed broken without failing anything.
+    """
+    auth = (os.environ.get("GEOSERVER_USER", "admin"),
+            os.environ.get("GEOSERVER_PASS", "geoserver"))
+    workspace = os.environ.get("DEMO_WORKSPACE", "invest")
+
+    listing = requests.get("%s/rest/workspaces/%s/layers.json"
+                           % (geoserver_url, workspace), auth=auth, timeout=60)
+    if listing.status_code == 404:
+        pytest.skip("needs the demo loaded (make demo): no %s workspace"
+                    % workspace)
+    assert listing.status_code == 200, listing.text[:500]
+    published = {layer["name"] for layer
+                 in listing.json().get("layers", {}).get("layer", [])}
+    if not published:
+        pytest.skip("needs the demo loaded (make demo): no published layers")
+
+    caps = requests.get("%s/ows" % geoserver_url, params={
+        "service": "WMS", "version": "1.3.0", "request": "GetCapabilities",
+    }, timeout=120)
+    assert caps.status_code == 200, caps.text[:500]
+    advertised = set(re.findall(r"<Name>%s:([^<]+)</Name>" % re.escape(workspace),
+                                caps.text))
+
+    missing = sorted(published - advertised)
+    assert not missing, (
+        "%d of %d layers are published but not advertised by WMS, so no client "
+        "can discover them: %s" % (len(missing), len(published), missing[:10]))

--- a/tools/easyows.py
+++ b/tools/easyows.py
@@ -282,10 +282,49 @@ class Catalog:
             resource.projection_policy = "FORCE_DECLARED"
             resource.enabled = True
             self.gs_cat.save(resource)
+            # Declaring the CRS is not enough to make the layer findable; see
+            # _recalculate_bounds.
+            self._recalculate_bounds(resource)
             self.logger.info("Declared %s for %s:%s (CRS match threshold %d%%)"
                              % (epsg, workspace, resource.name,
                                 _CRS_MIN_CONFIDENCE))
         return ok
+
+    def _recalculate_bounds(self, resource):
+        """Recompute a rescued layer's bounds, so WMS will advertise it.
+
+        GeoServer computes no latLonBoundingBox for a layer it imported without
+        a resolvable CRS -- it had no projection to derive one from. Declaring
+        the SRS afterwards does not backfill it: the bounds are only recomputed
+        when the write asks for it. WMS 1.3.0 cannot emit a layer that has no
+        EX_GeographicBoundingBox, so GeoServer silently drops it from
+        GetCapabilities.
+
+        The layer is enabled and serves correctly over WFS and WCS throughout,
+        which is why this hides from a publish-then-fetch round trip and
+        surfaces only as a layer no WMS client can discover -- it cost four of
+        the demo's layers before anyone noticed.
+        """
+        import json as _json
+
+        # The href carries the store kind (datastores vs coveragestores), which
+        # decides both the REST path and the name of the document element.
+        path = resource.href.partition("/rest/")[2]
+        for extension in (".xml", ".json", ".html"):
+            if path.endswith(extension):
+                path = path[:-len(extension)]
+                break
+        body = {resource.resource_type: {"srs": resource.projection}}
+        try:
+            status, _ = self._rest(
+                "%s.json?recalculate=nativebbox,latlonbbox" % path,
+                method="PUT", data=_json.dumps(body).encode())
+            return status in (200, 201)
+        except Exception as exc:  # noqa: BLE001
+            # A layer that serves but cannot be found beats no layer at all.
+            self.logger.warning("Could not recalculate bounds for %s: %s"
+                                % (resource.name, str(exc)[:160]))
+            return False
 
     # --- PostGIS -----------------------------------------------------------
     #


### PR DESCRIPTION
Four of the demo's layers have been invisible to every WMS client, while
passing every check we have.

### What happens

`easyows.Catalog.ensure_srs` rescues a layer GeoServer imported without a
resolvable CRS: it identifies the EPSG code, sets `FORCE_DECLARED`, and
re-enables the layer. That makes the layer **serve**, but not be **found**.

GeoServer computed no `latLonBoundingBox` at import time — it had no projection
to derive one from. Declaring the SRS afterwards does not backfill it; the
bounds are only recomputed when the write asks for it. WMS 1.3.0 cannot emit a
layer without an `EX_GeographicBoundingBox`, so GeoServer silently drops the
layer from `GetCapabilities`.

The layer stays `enabled=true`, `advertised=true`, correctly projected, and
serves fine over WFS and WCS. So publishing succeeds, and every
publish-then-fetch check passes — `run_model_jobs.py --ows` reports 25 of 25
with these layers broken. The only symptom is that nobody can discover them.

### The four

| Layer | nativeCRS | Declared |
|---|---|---|
| `forest_carbon_edge_effect_forest_carbon_edge_demo_aoi` | `PROJCS["Transverse_Mercator"]`, no datum | EPSG:32721 |
| `scenario_proximity_scenario_proximity_aoi` | `PROJCS["Transverse_Mercator"]`, no datum | EPSG:32721 |
| `urbannatureaccess_administrative_units` | `PROJCS["RGF93_Lambert_93"]`, ESRI-style name | EPSG:2154 |
| `forest_carbon_edge_effect_..._regression_model_parameters` | `PROJCS["Sinusoidal", GEOGCS["GCS_unknown"]]`, MODIS | EPSG:996842 |

These are exactly the CRS classes `crs_identify` was written to handle — the
identification is working. Only the bounds were left behind.

### The fix

Ask for the recalculation on the same write:
`?recalculate=nativebbox,latlonbbox`. Verified by hand against a live layer
before writing the code — the recomputed box for the RGF93/Lambert-93 admin
units came back as 1.44..3.56 E, 48.11..49.24 N, which is Île-de-France, i.e.
correct rather than merely present.

### The test

`test_every_published_layer_is_advertised_by_wms` asserts the property that was
actually violated — every published layer is advertised by WMS — rather than
that publishing returned 200, which it always did. Confirmed it fails on the
broken layers (naming exactly the 3 I had not hand-repaired) before it passed.

### Verification

- `make down && make verify` on a wiped GeoServer volume, so every layer
  republished from scratch through the new code: **85 passed, 0 failed, 0
  skipped**
- Layers in the `invest` workspace advertised by WMS: **72 of 76 → 76 of 76**
- `run_model_jobs.py --ows`: 25 passed, 0 failed, 1 skipped (recreation, which
  needs NatCap's remote server) — unchanged, as expected, since these layers
  always served correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi