### PR TITLE
Ignore per-machine Claude Code state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ src
 .env
 # mountpoint for the results_tables volume (see docker-compose.yml)
 data/results/
+# Per-machine Claude Code state: settings.local.json holds personal permission
+# rules, the lock file is runtime scratch. A shared .claude/settings.json is
+# deliberately not ignored -- that one is meant to be committed.
+.claude/settings.local.json
+.claude/*.lock


### PR DESCRIPTION
`.claude/settings.local.json` (personal permission rules) and
`.claude/scheduled_tasks.lock` (runtime scratch) were both untracked and
unignored — one `git add -A` away from being committed as project config.

`.claude/settings.json` is deliberately left tracked: that is the shared,
team-wide file, and ignoring the whole directory would rule out ever
committing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi