### PR TITLE
Move the Python floor to 3.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,10 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     ignore:
-      # Sphinx 9.1 requires Python >= 3.12 and the docs build runs in the InVEST
-      # conda environment, which is on 3.11. Drop this when InVEST moves, so the
-      # bump can be taken.
+      # Sphinx 9.1 requires Python >= 3.12. The environment now provides it, so
+      # this is no longer a hard block -- the bump is just not taken yet, and it
+      # rewrites every page of the committed docs/, so it moves deliberately on
+      # its own. Drop this entry when it does.
       - dependency-name: sphinx
         versions: [">=9.1"]
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.11'   # the version the wps image runs
+          python-version: '3.12'   # the version the wps image runs
 
       - name: Byte-compile every live module
         # Catches what the container would otherwise only reveal on start, and

--- a/docker/Dockerfile.baremetal-check
+++ b/docker/Dockerfile.baremetal-check
@@ -35,7 +35,7 @@ RUN mkdir -p "$HOME/.local/bin" && \
         | tar -xj -C "$HOME/.local" bin/micromamba
 
 RUN "$HOME/.local/bin/micromamba" create -y -p "$HOME/esws-invest" -c conda-forge \
-        python=3.11 \
+        python=3.12 \
         "gdal=3.10.*" \
         "pygeoprocessing>=2.4.10" \
         c-compiler cxx-compiler cython numpy \

--- a/docker/Dockerfile.invest
+++ b/docker/Dockerfile.invest
@@ -10,10 +10,17 @@ FROM mambaorg/micromamba:2.8.1
 # Install requirements file early for better layer caching.
 COPY --chown=$MAMBA_USER:$MAMBA_USER requirements/server.txt /tmp/server.txt
 
-# Python 3.11 + GDAL 3.x + compilers/cython so `pip install natcap.invest` can
-# build its extensions from sdist if no wheel is available for this platform.
+# Python + GDAL 3.x + compilers/cython so `pip install natcap.invest` can build
+# its extensions from sdist if no wheel is available for this platform.
+#
+# 3.12, not 3.11: natcap.invest 3.20.0 declares requires_python >=3.10 and
+# classifies 3.10-3.14, so the old 3.11 was ESWS's own choice rather than a
+# constraint -- and it was what held Django at 5.2 and Sphinx at 9.0.4, both of
+# which need >=3.12. conda-forge builds the whole geo stack for 3.12 (gdal
+# 3.10.3, pygeoprocessing 2.4.11). Keep this in step with install.sh and
+# docker/Dockerfile.baremetal-check.
 RUN micromamba install -y -n base -c conda-forge \
-        python=3.11 \
+        python=3.12 \
         "gdal=3.10.*" \
         # GDAL's PostgreSQL/PostGIS driver is a separate conda package. Without
         # it OGR has only PGDUMP -- write a .sql file, not talk to a database --

--- a/docsrc/requirements.txt
+++ b/docsrc/requirements.txt
@@ -9,9 +9,10 @@
 # once). alabaster is pinned too -- it is what actually emits the HTML, so it
 # moves the output as much as sphinx does. Bump these deliberately, then rebuild
 # and commit the resulting docs/ churn as its own change.
-# 9.0.4 is the last release that runs on Python 3.11, which is what the InVEST
-# conda environment pins -- and the build needs that environment for MODEL_SPEC.
-# Sphinx 9.1 requires >= 3.12; bump this when InVEST moves.
+# 9.0.4 was the last release that ran on Python 3.11, which the InVEST conda
+# environment used to pin. That environment is on 3.12 now, so Sphinx 9.1 is
+# available -- this stays at 9.0.4 only until the bump is taken deliberately,
+# because it rewrites every page and all of _static in the committed docs/.
 sphinx==9.0.4
 sphinxcontrib-mermaid==2.1.0
 alabaster==1.0.0

--- a/install.sh
+++ b/install.sh
@@ -62,8 +62,11 @@ if [ ! -x "$HOME/.local/bin/micromamba" ]; then
     curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest \
         | tar -xj -C "$HOME/.local" bin/micromamba
 fi
+# Keep the Python in step with docker/Dockerfile.invest -- the docs build reads
+# MODEL_SPEC from whatever InVEST this env has, so a drifting env documents the
+# wrong thing silently.
 "$HOME/.local/bin/micromamba" create -y -p "$ESWS_ENV" -c conda-forge \
-    python=3.11 \
+    python=3.12 \
     "gdal=3.10.*" \
     "pygeoprocessing>=2.4.10" \
     c-compiler cxx-compiler cython numpy \

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -39,8 +39,10 @@ geoserver-restconfig
 
 # --- Django dashboard (tools/wpsclient) ---
 # 4.2's extended support ended in April 2026; 5.2 is the current LTS, supported
-# to April 2028. Django 6.0 requires Python >= 3.12 and the image is on 3.11,
-# pinned by the InVEST conda environment, so 5.2 is as far as this can go.
+# to April 2028. Django 6.0 needs Python >= 3.12, which the image now has -- so
+# 6.0 is reachable and is simply not taken yet. It is a major version and the
+# dashboard's syncdb-only migration setup is the risky part, so it moves on its
+# own, not as a side effect of the Python bump.
 Django==5.2.*
 django-extensions
 owslib


### PR DESCRIPTION
The 3.11 pin was ESWS's own choice, not a constraint anyone imposed on it — and
it was the only thing keeping Django at 5.2 and Sphinx at 9.0.4, both of which
need >= 3.12.

Several comments in the repo asserted that InVEST pinned it. It does not:
`natcap.invest` 3.20.0 declares `requires_python: >=3.10` and carries
classifiers for **3.10, 3.11, 3.12, 3.13 and 3.14**.

What *is* a real ceiling is InVEST's own `gdal==3.10.*`, which is why GDAL stays
where it is regardless of what Python does. (`natcap.invest` 3.20.0 is also
already the latest release on PyPI, so there is nothing to move to there.)

### What moved

Four places, which had to go together:

| File | Why |
|---|---|
| `docker/Dockerfile.invest` | the stack image |
| `install.sh` | the bare-metal env (`~/esws-invest`), which the docs build also uses |
| `docker/Dockerfile.baremetal-check` | the clean-machine stand-in |
| `.github/workflows/checks.yml` | CI pins its Python to match the image — otherwise it byte-compiles against a version nothing runs |

### Verification

The risk was never the conda solve — it was whether InVEST's Cython extensions
still build. InVEST publishes no Linux wheels, so this compiles it from sdist
against conda-forge GDAL 3.10.

- **`make check-baremetal`** — clean Ubuntu, runs `install.sh`'s steps, builds
  InVEST from sdist. Produced
  `natcap_invest-3.20.0-cp312-cp312-linux_x86_64.whl` and asserted
  invest 3.20.0 / gdal 3.10.3 / django 5.2.17 / 26 models. **OK**
- **`make down && make verify`** — full suite on a *wiped* GeoServer volume, so
  every layer republishes through the 3.12 image:
  **85 passed, 0 failed, 0 skipped** (`platform linux -- Python 3.12.13`)
- **`make unit`** — 52 passed

### Deliberately not included

Django 6.0 and Sphinx 9.1 are now reachable but are **not** taken here. Django
6.0 is a major version against a `MIGRATION_MODULES = {'wpsclient': None}` /
`--run-syncdb` setup, and Sphinx 9.1 rewrites every page and all of `_static` in
the committed `docs/`. Each moves on its own so a failure in either is not
tangled up with the enabler.

The comments and the Dependabot `ignore` are reworded from "blocked" to "not
taken yet", since the distinction is the whole point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi