### PR TITLE
Take Sphinx 9.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    ignore:
-      # Sphinx 9.1 requires Python >= 3.12. The environment now provides it, so
-      # this is no longer a hard block -- the bump is just not taken yet, and it
-      # rewrites every page of the committed docs/, so it moves deliberately on
-      # its own. Drop this entry when it does.
-      - dependency-name: sphinx
-        versions: [">=9.1"]
 
   - package-ecosystem: docker
     directory: /docker

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -246,7 +246,7 @@ starts it empty – run <code class="docutils literal notranslate"><span class="
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/extensions.html
+++ b/docs/extensions.html
@@ -101,7 +101,7 @@
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -455,7 +455,7 @@ window.runMermaid = runMermaid;</script>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -278,7 +278,7 @@ to a server of your choosing.</p>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/install.html
+++ b/docs/install.html
@@ -192,7 +192,7 @@ documentation describes it. Use Compose.</p>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/models.html
+++ b/docs/models.html
@@ -1295,7 +1295,7 @@ the diagrams too, but every process does accept it.</p>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/processes.html
+++ b/docs/processes.html
@@ -572,7 +572,7 @@ the connection open for the whole run.</p>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/rasters.html
+++ b/docs/rasters.html
@@ -190,7 +190,7 @@ such a reference stripped, leaving a CRS every client can read on its own terms.
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/run.html
+++ b/docs/run.html
@@ -286,7 +286,7 @@ resubmits it and says which of the two will happen.</p>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/search.html
+++ b/docs/search.html
@@ -473,7 +473,7 @@ window.runMermaid = runMermaid;</script>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
     </div>

--- a/docs/tables.html
+++ b/docs/tables.html
@@ -141,7 +141,7 @@ a plain file server has no upload protocol of its own. See
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/tut.html
+++ b/docs/tut.html
@@ -157,7 +157,7 @@
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/tut_data.html
+++ b/docs/tut_data.html
@@ -195,7 +195,7 @@ model the data needed for this model is as follows:</p>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/tut_invest_wy.html
+++ b/docs/tut_invest_wy.html
@@ -939,7 +939,7 @@ maps of the other outputs from InVEST.</p></li>
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docs/vectors.html
+++ b/docs/vectors.html
@@ -111,7 +111,7 @@ before the model runs. The same CRS caveat applies as for rasters
       &#169;.
       
       |
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
       &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
       
       |

--- a/docsrc/requirements.txt
+++ b/docsrc/requirements.txt
@@ -9,10 +9,11 @@
 # once). alabaster is pinned too -- it is what actually emits the HTML, so it
 # moves the output as much as sphinx does. Bump these deliberately, then rebuild
 # and commit the resulting docs/ churn as its own change.
-# 9.0.4 was the last release that ran on Python 3.11, which the InVEST conda
-# environment used to pin. That environment is on 3.12 now, so Sphinx 9.1 is
-# available -- this stays at 9.0.4 only until the bump is taken deliberately,
-# because it rewrites every page and all of _static in the committed docs/.
-sphinx==9.0.4
+# 9.1 needs Python >= 3.12, which the InVEST conda environment provides since the
+# Python floor moved. Taken deliberately, with the docs/ churn it causes committed
+# alongside it -- and only after confirming on the same environment that 9.0.4
+# still reproduced the committed output byte for byte, so the churn below is
+# attributable to Sphinx and nothing else.
+sphinx==9.1.0
 sphinxcontrib-mermaid==2.1.0
 alabaster==1.0.0


### PR DESCRIPTION
Sphinx 9.1 needs Python >= 3.12, which the docs environment has since the Python
floor moved. The Dependabot `ignore` that held it back goes with it.

### The entire docs/ churn

```diff
-      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.0.4</a>
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 9.1.0</a>
```

15 files, 15 insertions, 15 deletions — one line per page. No content changes,
no `_static`, no new files.

The note in `docsrc/requirements.txt` warning that a Sphinx bump "rewrites every
page and all of `_static`" came from the **9.x major** bump. A minor does not
behave that way, and there is now a measurement saying so rather than a
recollection.

### Why the diff is trustworthy

Because the environment moved first and was checked on its own. The docs env was
rebuilt on Python 3.12 while Sphinx stayed at 9.0.4, and rebuilding from that
env reproduced the committed `docs/` **byte for byte — zero changed files**.

So nothing in this PR is attributable to the interpreter; it is all Sphinx, and
Sphinx changed exactly one string.

Doing it the other way round — bumping Python and Sphinx together — would have
produced the same 15-line diff with no way to tell which caused it, and no
baseline to compare against next time.

### Verification

- Docs build with `-W` (warnings are errors) — **build succeeded**, zero warnings
- `alabaster` 1.0.0 unchanged and still compatible
- `make unit` — 52 passed
- `.github/dependabot.yml` parses as valid YAML after the `ignore` removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi