### PR TITLE
Take Django 6.1

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -38,12 +38,17 @@ flask-cors
 geoserver-restconfig
 
 # --- Django dashboard (tools/wpsclient) ---
-# 4.2's extended support ended in April 2026; 5.2 is the current LTS, supported
-# to April 2028. Django 6.0 needs Python >= 3.12, which the image now has -- so
-# 6.0 is reachable and is simply not taken yet. It is a major version and the
-# dashboard's syncdb-only migration setup is the risky part, so it moves on its
-# own, not as a side effect of the Python bump.
-Django==5.2.*
+# 6.1, the current release, on Python >= 3.12 which the image now has.
+#
+# This deliberately leaves the LTS track, so the trade is worth stating: 5.2 is
+# an LTS supported to April 2028, while 6.1 is a feature release with roughly a
+# 16-month window. Chosen over 6.0 because if you are leaving LTS anyway, the
+# newer release buys the longer runway for the same compatibility risk. The next
+# LTS is 6.2 (April 2027) and is the natural next stop.
+#
+# tools/wpsclient/requirements_py3.txt pins this too and must move with it --
+# see the comment there for what silently breaks when it does not.
+Django==6.1.*
 django-extensions
 owslib
 beautifulsoup4

--- a/tools/wpsclient/requirements_py3.txt
+++ b/tools/wpsclient/requirements_py3.txt
@@ -13,5 +13,5 @@
 # "DASHBOARD SUBSET OK" step of docker/Dockerfile.baremetal-check meaningless:
 # it dry-run installs this file into the env built from server.txt, so a lower
 # pin resolves as a *downgrade* and still exits 0. Bump both together.
-Django==5.2.*
+Django==6.1.*
 owslib


### PR DESCRIPTION
Django 6.1 needs Python >= 3.12, which the image has since the Python floor
moved. Both pins move together — `requirements/server.txt` and
`tools/wpsclient/requirements_py3.txt` — because they are copies of each other
and `check-baremetal` passes vacuously when they drift (see #84).

### This leaves the LTS track, deliberately

5.2 is an LTS supported to **April 2028**; 6.1 is a feature release with roughly
a 16-month window. Chosen over 6.0 because the compatibility risk is identical
and the newer release buys a longer runway. **6.2 (April 2027) is the next LTS**
and the natural next stop.

### The risky part was fine

The dashboard's migration setup is unusual: `MIGRATION_MODULES = {'wpsclient': None}`
with tables created by `migrate --run-syncdb`, because the app source is mounted
read-only. That is off the documented path, so it was worth checking rather than
assuming — but neither the 6.0 nor the 6.1 release notes carry a
backwards-incompatible change to `run-syncdb`, `MIGRATION_MODULES`, the migration
executor, or migration state. The dashboard container cannot start unless
`--run-syncdb` succeeds, so the stack coming up is itself the proof.

The one 6.1 requirement that could have bitten is SQLite: the minimum rises from
3.31.0 to **3.37.0**, and the dashboard is on SQLite. The image ships **3.53.4**.

### Verification

- **`make down && make verify`** — full suite on a wiped GeoServer volume:
  **85 passed, 0 failed, 0 skipped** (`Python 3.12.13, django 6.1`)
- **Form-rendering performance: no regression.** The dashboard generates every
  form from `MODEL_SPEC`, so each raster/vector input becomes a `ModelChoiceField`
  rendering a `<select>` through Django's template engine — a per-node cost change
  would compound badly here. Measured directly (12 fields x 50 choices, settled
  stack, 7 reps):

  | Django | per-form median | min |
  |---|---|---|
  | 5.2.17 | 27.9 ms | 27.8 ms |
  | 6.1 | 28.5 ms | 28.3 ms |

  1.02x — parity.

An earlier round of measurements appeared to show a ~3x slowdown. That was an
artifact of benchmarking seconds after `docker compose up -d`, while GeoServer
was still initializing; the profile showed identical call counts
(102,860 node renders on both), which is the signature of a loaded host rather
than a code change. The table above is from a settled stack.

### Unrelated defect noticed

`test_change_detection_distinguishes_changed_from_unchanged` fails when the suite
runs a **second** time against the same stack: it registers a probe CSV and
asserts the first check reports `changed == 0`, but on a re-run the probe is
already fingerprinted from the previous run's final content. Reproduced on 5.2
as well, so it predates this change and is not fixed here. A run-unique probe
name would do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi