### PR TITLE
Give the change-detection probe a run-unique name

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3,6 +3,7 @@ import html
 import os
 import re
 import time
+import uuid
 from urllib.parse import quote
 
 import pytest
@@ -490,7 +491,21 @@ def test_change_detection_distinguishes_changed_from_unchanged(dashboard_url):
                              r'<td align="right">(\d+)</td>', page))))
         return tally, page
 
-    probe = "results/change_probe_test.csv"
+    # A name unique to this run, because the assertion below is specifically
+    # about an element nothing has fingerprinted yet. The registration and its
+    # fingerprint live in the dashboard's database, which outlives the test, so
+    # a fixed name makes the second run against one stack start with the
+    # previous run's *final* content already recorded -- writing the initial
+    # content back is then itself a change, and "a first fingerprint is not a
+    # change" fails. Reproduced on Django 5.2 and 6.1 alike; it is the suite
+    # being run twice that triggers it, not any version.
+    #
+    # test_a_reactive_job_reruns_when_its_input_changes solves the same problem
+    # by checking once to establish a baseline, which suits it because it only
+    # needs a known starting point. That would not work here: it would make the
+    # check below the second one, and a second fingerprint is not what this
+    # test is about.
+    probe = "results/change_probe_%s.csv" % uuid.uuid4().hex[:8]
     _write_shared_table(probe, "lucode,root_depth\n1,1000\n")
     requests.get("%s/server/CSV/%d/register/%s/"
                  % (dashboard_url, pk, quote(probe, safe="")), timeout=60)


### PR DESCRIPTION
`test_change_detection_distinguishes_changed_from_unchanged` failed whenever the
suite ran a **second** time against one stack — 85 passed on the first run, 84
passed and 1 failed on the second.

### Why

The probe's registration and its fingerprint live in the dashboard's database,
which outlives the test. With a fixed path, the second run starts with the
*previous* run's final content already fingerprinted — so writing the initial
content back is itself a change, the first check reports `changed=1`, and this
assertion fails:

```python
first, _ = check()
assert first["changed"] == 0, first        # a first fingerprint is not a change
```

Nothing about the code under test was wrong. The test simply could not run twice.

It stayed hidden because `make verify` starts from `down -v`, which throws the
database away. Reproduced on **Django 5.2 and 6.1 alike**, so it is the second
run that triggers it, not any version — it surfaced during the 6.1 work and was
briefly suspected of being a regression.

### Why a unique name rather than a baseline check

`test_a_reactive_job_reruns_when_its_input_changes` solves the same re-run
problem by checking once first to establish a baseline, and says so in a comment.
That suits it, because it only needs a known starting point.

It would not suit this test. Checking first would make the assertion above the
*second* fingerprint, so the test would keep its name while quietly no longer
testing what the name claims. A run-unique probe keeps the element genuinely
fresh, which is the state the assertion is about.

### Verification

Full suite, twice in a row against a single stack:

| | run 1 | run 2 |
|---|---|---|
| before | 85 passed | **84 passed, 1 failed** |
| after | 85 passed | **85 passed** |

`make unit` — 52 passed.

### Noticed, not fixed here

`server_element_register` (`views.py:372-376`) uses `get_or_create` so
re-registering does not duplicate a row — but then increments
`server.registrations` unconditionally, whether or not anything was created.
`server_element_unregister` mirrors it, decrementing even when the filter matched
nothing. No test depends on the counter, but it is displayed in `dashboard.html`,
`server_detail.html` and `server_element_list.html`, so the shown count drifts
from reality. `_created` is already captured and discarded. Separate concern,
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNHxJ3YoSh4XKQodjjffzi