### PR TITLE
Install lxml in CI, so the BPMN tests stop skipping

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,5 +36,11 @@ jobs:
           # pyproj because the CRS rules are checked against real definitions --
           # that EPSG:6842 is Oregon Coast, not the MODIS grid, is the sort of
           # thing only the registry can tell you.
-          python -m pip install --quiet pytest pyproj
+          #
+          # lxml because the BPMN tests `pytest.importorskip` it, and without it
+          # they skip rather than fail: CI reported "49 passed, 3 skipped" and
+          # looked green while the export was never validated against the OMG
+          # schema at all. The schema is vendored (tests/data/BPMN20.xsd), so
+          # lxml was the only thing missing. A skip is not a pass.
+          python -m pip install --quiet pytest pyproj lxml
           python -m pytest tests/unit -q


### PR DESCRIPTION
CI reported **`49 passed, 3 skipped`** and looked green. The three skips were the
BPMN tests, which `pytest.importorskip("lxml.etree")` and therefore *skip* rather
than fail when lxml is absent — and the workflow installed only `pytest` and
`pyproj`.

One of them is `test_bpmn_validates_against_the_omg_schema`, so the BPMN export
has never once been validated against the OMG schema in CI.

Straight from the log of a real run (the Django 6.1 check that passed):

```
SKIPPED [1] tests/unit/test_job_graph.py:85: could not import 'lxml.etree': No module named 'lxml'
SKIPPED [1] tests/unit/test_job_graph.py:97: could not import 'lxml.etree': No module named 'lxml'
SKIPPED [1] tests/unit/test_job_graph.py:118: could not import 'lxml.etree': No module named 'lxml'
49 passed, 3 skipped, 1 warning in 0.41s
```

The schema is already vendored (`tests/data/BPMN20.xsd` and the four it imports),
so lxml was the only missing piece. No test and no code needed changing.

### Why it went unnoticed

`make unit` on a developer machine reports **52 passed** — the host Python happens
to have lxml. The gap exists only in the clean environment `actions/setup-python`
provides, which is precisely the environment nobody inspects while the check is
green.

### Verification

This PR's own check, on the runner that had the gap:

```
52 passed, 1 warning in 0.43s
```

| | result |
|---|---|
| before | `49 passed, 3 skipped` |
| after | `52 passed, 0 skipped` |

The three BPMN tests now execute in CI, and the export is validated against the
OMG schema there for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWfVxbSMiA9BZ68yce9ymR
