### PR TITLE
Stop a pip-pin edit from re-solving the whole conda stack

### DIFF
--- a/docker/Dockerfile.invest
+++ b/docker/Dockerfile.invest
@@ -7,9 +7,6 @@
 # Shared by the `wps` and `fileserver` compose services.
 FROM mambaorg/micromamba:2.8.1
 
-# Install requirements file early for better layer caching.
-COPY --chown=$MAMBA_USER:$MAMBA_USER requirements/server.txt /tmp/server.txt
-
 # Python + GDAL 3.x + compilers/cython so `pip install natcap.invest` can build
 # its extensions from sdist if no wheel is available for this platform.
 #
@@ -42,6 +39,13 @@ RUN micromamba install -y -n base -c conda-forge \
 # the micromamba entrypoint).
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
+# Copied *after* micromamba, not before. The conda step does not read this file,
+# so copying it earlier only meant that editing a pip pin invalidated the whole
+# GDAL/compiler install too -- 56s of solving re-run to change one line that step
+# never looks at. Copying it here is what "early for better layer caching"
+# was reaching for: early relative to pip, late relative to conda.
+COPY --chown=$MAMBA_USER:$MAMBA_USER requirements/server.txt /tmp/server.txt
+
 # InVEST publishes no Linux wheels, so it builds from sdist here. Its build
 # requirements include pygeoprocessing, and in pip's *isolated* build
 # environment that resolves the newest GDAL bindings off PyPI -- which then
@@ -50,8 +54,16 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 # build requirements for exactly this reason, so build it against the
 # conda-forge stack above instead of an isolated one. Everything else installs
 # normally; natcap.invest is already satisfied by then.
-RUN pip install --no-cache-dir --no-build-isolation natcap.invest==3.20.0 && \
-    pip install --no-cache-dir -r /tmp/server.txt
+#
+# --mount=type=cache rather than --no-cache-dir: the reason for --no-cache-dir
+# was image size, and a cache mount is not part of the layer, so it keeps the
+# image just as small while letting a rebuild reuse the downloads and the wheel
+# pip built from InVEST's sdist. uid/gid are mambauser's (57439); the default
+# mount is root-owned and this image does not run as root, so pip would fall
+# back to an unwritable cache and silently gain nothing.
+RUN --mount=type=cache,target=/home/mambauser/.cache/pip,uid=57439,gid=57439 \
+    pip install --no-build-isolation natcap.invest==3.20.0 && \
+    pip install -r /tmp/server.txt
 
 # pywps writes stored ExecuteResponse documents and referenced outputs here
 # (outputpath in tools/wpsserver/pywps.cfg). Create it as the image user so the


### PR DESCRIPTION
Editing a single line in `requirements/server.txt` cost **6m26s** to rebuild the
wps image. **56.5s of that was micromamba re-solving and re-installing GDAL, the
compilers and pygeoprocessing** — a step that never reads the file.

The `COPY` sat above it:

```dockerfile
COPY requirements/server.txt /tmp/server.txt   # line 11
RUN micromamba install ... gdal ... cython ...  # line 22  <- invalidated too
RUN pip install --no-cache-dir ...              # line 53
```

The comment called this *"early for better layer caching"*, which was the right
instinct aimed one step too high: early relative to pip, but also early relative
to conda. Moving the `COPY` below the micromamba step keeps that layer cached.

### Two changes

1. **`COPY server.txt` moved below the micromamba install** — the conda layer now
   survives a pip-pin edit.
2. **BuildKit cache mount on the pip step**, replacing `--no-cache-dir` — a
   rebuild reuses the downloads and, more importantly, the wheel pip built from
   InVEST's sdist. InVEST publishes no Linux wheels, so that sdist build is the
   expensive half of the step.

### Measured

Editing one line of `requirements/server.txt` and rebuilding:

| | before | after |
|---|---|---|
| micromamba install | 56.5s | **CACHED** |
| pip install | 133.2s | 70.5s |
| **total** | **6m26s** | **2m39s** |

~59% faster. Both figures are a real `docker compose build wps` on the same
machine, same one-line edit, with layers warm beforehand.

### On dropping `--no-cache-dir`

That flag was there for image size, and a cache mount is not part of the layer,
so the reason survives the change. Verified rather than assumed:

- image is **3.42GB before and after**
- `/home/mambauser/.cache/pip` **does not exist** in the built image

The `uid=57439,gid=57439` on the mount are mambauser's. The default cache mount
is root-owned and this image does not run as root, so without them pip falls back
to an unwritable cache and silently gains nothing — the failure mode is a
no-op that still looks like it worked.

### Verification

From the rebuilt image: `natcap.invest 3.20.0`, `pygeoprocessing 2.4.11`,
`gdal 3.10.3`, `django 6.1` — all matching their pins. `tests/unit` passes 52.

`docker/Dockerfile.baremetal-check` was checked for the same bug and does not
have it — it already copies its requirements after the apt step.

### Scope note

CI does not build images, so this does not affect the `checks` workflow (which is
~7s of step work and wants no caching — a stale-environment cache there is the
same failure class as #91). The beneficiaries are `make build` / `make smoke`
locally and the deploy host, on rebuilds that touch dependencies — which recent
history does show (Django 6.1, Sphinx 9.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWfVxbSMiA9BZ68yce9ymR
