### PR TITLE
Give the dashboard accounts, and scope what each one sees

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@
 GEOSERVER_USER=admin
 GEOSERVER_PASS=geoserver
 
+# The dashboard's first administrator, created on start if it does not exist.
+# Unrelated to the GeoServer credentials above: the dashboard has its own
+# accounts, and an admin there sees every user's servers, elements and jobs.
+# Everyone else is added through the Django admin at /admin/.
+DASHBOARD_ADMIN_USER=admin
+DASHBOARD_ADMIN_PASS=esws-admin
+DASHBOARD_ADMIN_EMAIL=admin@example.invalid
+
 # Host port overrides (container ports are unchanged). Set these if the defaults
 # collide with other stacks on the host. GEOSERVER_HOST_PORT also determines the
 # GeoServer URL the WPS advertises to clients for published layers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,13 @@ services:
 
   dashboard:
     image: esws/wps  # see fileserver
+    # createsuperuser --noinput reads DJANGO_SUPERUSER_*. It exits non-zero once
+    # the account exists, which is every start after the first, so its failure is
+    # ignored -- without it the dashboard would come up with no account able to
+    # log into it, and every page would redirect to a login nobody can pass.
     command: >
       sh -c "python tools/wpsclient/manage.py migrate --run-syncdb &&
+             (python tools/wpsclient/manage.py createsuperuser --noinput || true) &&
              python tools/wpsclient/manage.py runserver 0.0.0.0:8000"
     ports:
       - "${DASHBOARD_HOST_PORT:-8000}:8000"
@@ -100,6 +105,13 @@ services:
       DJANGO_ALLOWED_HOSTS: "*"
       DJANGO_DB_PATH: /tmp/esws-db.sqlite3
       WPS_SERVER_URL: http://wps:5000/wps
+      # The first administrator. Everyone else is created through the Django
+      # admin at /admin/; this one exists so there is somebody to create them.
+      # An admin sees every user's servers, elements and jobs, which is what the
+      # dashboard did for everyone before there were accounts.
+      DJANGO_SUPERUSER_USERNAME: ${DASHBOARD_ADMIN_USER:-admin}
+      DJANGO_SUPERUSER_PASSWORD: ${DASHBOARD_ADMIN_PASS:-esws-admin}
+      DJANGO_SUPERUSER_EMAIL: ${DASHBOARD_ADMIN_EMAIL:-admin@example.invalid}
     depends_on:
       - wps
 

--- a/scripts/load_demo.py
+++ b/scripts/load_demo.py
@@ -17,8 +17,10 @@ tops up rather than duplicating.
   make demo
 """
 import argparse
+import http.cookiejar
 import json
 import os
+import re
 import sys
 import urllib.parse
 import urllib.request
@@ -47,9 +49,51 @@ def log(msg):
     print(msg, flush=True)
 
 
+DASHBOARD_USER = os.environ.get("DASHBOARD_ADMIN_USER", "admin")
+DASHBOARD_PASS = os.environ.get("DASHBOARD_ADMIN_PASS", "esws-admin")
+
+# Cookies for the dashboard session. The dashboard is multi-user now: an
+# unauthenticated request is redirected to the login page, and urllib follows
+# that redirect, so every registration below would come back HTTP 200 from the
+# login form having registered nothing at all. Signing in first is what makes
+# the 200s mean what this script checks them for.
+_opener = urllib.request.build_opener(
+    urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar()))
+
+
 def http_get(url, timeout=120):
-    with urllib.request.urlopen(url, timeout=timeout) as r:
+    with _opener.open(url, timeout=timeout) as r:
         return r.status, r.read().decode("utf-8", "replace")
+
+
+def dashboard_login(timeout=120):
+    """Sign the shared opener in as the dashboard administrator.
+
+    The demo registers sources on everyone's behalf, so it runs as an admin --
+    whose view is the whole catalogue, which is what the demo is meant to set up.
+    Django's login form is CSRF-protected: the token comes from the form and has
+    to go back with the credentials, the cookie and a matching Referer.
+    """
+    login_url = DASHBOARD + "/accounts/login/"
+    status, body = http_get(login_url, timeout=timeout)
+    if status != 200:
+        raise RuntimeError("dashboard login page -> HTTP %s" % status)
+
+    found = re.search(r'name="csrfmiddlewaretoken" value="([^"]+)"', body)
+    if not found:
+        raise RuntimeError("no CSRF token on the dashboard login page")
+
+    data = urllib.parse.urlencode({
+        "username": DASHBOARD_USER, "password": DASHBOARD_PASS,
+        "csrfmiddlewaretoken": found.group(1), "next": "/"}).encode()
+    request = urllib.request.Request(login_url, data=data,
+                                     headers={"Referer": login_url})
+    with _opener.open(request, timeout=timeout) as response:
+        landed = response.geturl()
+    if landed.rstrip("/").endswith("/accounts/login"):
+        raise RuntimeError(
+            "could not sign in to the dashboard as %r -- check "
+            "DASHBOARD_ADMIN_USER/DASHBOARD_ADMIN_PASS" % DASHBOARD_USER)
 
 
 # --------------------------------------------------------------------------- #
@@ -164,7 +208,6 @@ def register_server(server_type, title, url):
         raise RuntimeError("register %s -> HTTP %s" % (server_type, status))
 
     status, body = http_get("%s/server/%s/" % (DASHBOARD, server_type))
-    import re
     pks = [int(p) for p in re.findall(r"/server/%s/(\d+)/" % server_type, body)]
     if not pks:
         raise RuntimeError("no %s server registered" % server_type)
@@ -204,6 +247,9 @@ def main():
         published = publish(cat, files)
     else:
         published["table"] = [p for p, k in files.items() if k == "table"]
+
+    log(">> Signing in to the dashboard as %s" % DASHBOARD_USER)
+    dashboard_login()
 
     log(">> Registering sources in the dashboard")
     csv_pk = register_server("CSV", "Local HTTP", FILESERVER)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,47 @@ def wps_url():
 
 @pytest.fixture(scope="session")
 def dashboard_url():
-    _wait(DASHBOARD_URL + "/", predicate=lambda r: r.status_code == 200)
+    # The login page rather than "/": every dashboard view requires a login now,
+    # so "/" redirects here anyway, and waiting on it would only prove the
+    # redirect works.
+    _wait(DASHBOARD_URL + "/accounts/login/",
+          predicate=lambda r: r.status_code == 200)
     return DASHBOARD_URL
+
+
+@pytest.fixture(scope="session")
+def dashboard(dashboard_url):
+    """A requests.Session signed in as the dashboard administrator.
+
+    The dashboard is multi-user: an anonymous request is redirected to the login
+    page, and a signed-in non-admin sees only their own rows. These tests assert
+    on what the stack as a whole produces, so they run as the admin -- the view
+    that matches how the dashboard behaved before there were accounts.
+
+    Django's login form is CSRF-protected, so the token has to be read from the
+    login page and sent back with the credentials and the cookie.
+    """
+    import requests
+
+    user = os.environ.get("DASHBOARD_ADMIN_USER", "admin")
+    password = os.environ.get("DASHBOARD_ADMIN_PASS", "esws-admin")
+
+    session = requests.Session()
+    login_url = dashboard_url + "/accounts/login/"
+    page = session.get(login_url, timeout=30)
+    token = session.cookies.get("csrftoken")
+    assert token, "no csrftoken cookie from %s: %s" % (login_url, page.text[:300])
+
+    posted = session.post(login_url,
+                          data={"username": user, "password": password,
+                                "csrfmiddlewaretoken": token, "next": "/"},
+                          headers={"Referer": login_url},
+                          timeout=30, allow_redirects=True)
+    assert posted.status_code == 200, posted.text[:500]
+    assert "sessionid" in session.cookies, (
+        "signing in as %s did not set a session cookie -- is DJANGO_SUPERUSER_* "
+        "set on the dashboard service? %s" % (user, posted.text[:500]))
+    return session
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,23 +10,23 @@ import pytest
 import requests
 
 
-def test_dashboard_home(dashboard_url):
-    r = requests.get(dashboard_url + "/", timeout=30)
+def test_dashboard_home(dashboard, dashboard_url):
+    r = dashboard.get(dashboard_url + "/", timeout=30)
     assert r.status_code == 200, r.text[:500]
 
 
-def test_dashboard_server_list(dashboard_url):
-    r = requests.get(dashboard_url + "/server/WPS/", timeout=30)
+def test_dashboard_server_list(dashboard, dashboard_url):
+    r = dashboard.get(dashboard_url + "/server/WPS/", timeout=30)
     assert r.status_code == 200, r.text[:500]
 
 
-def test_dashboard_job_list(dashboard_url):
-    r = requests.get(dashboard_url + "/job/", timeout=30)
+def test_dashboard_job_list(dashboard, dashboard_url):
+    r = dashboard.get(dashboard_url + "/job/", timeout=30)
     assert r.status_code == 200, r.text[:500]
 
 
 @pytest.fixture(scope="module")
-def registered_wps_server(dashboard_url, wps_url):
+def registered_wps_server(dashboard, dashboard_url, wps_url):
     """A WPS server registered in the dashboard, returning its primary key.
 
     Everything below needs one: with no servers the list template never enters
@@ -38,34 +38,34 @@ def registered_wps_server(dashboard_url, wps_url):
     calls GetCapabilities server-side to list processes, and the WPS takes some
     seconds to import all 26 InVEST models on start.
     """
-    r = requests.get(
+    r = dashboard.get(
         "%s/server/WPS/register/Smoke WPS/url/%s" % (dashboard_url, wps_url),
         timeout=60)
     assert r.status_code == 200, r.text[:500]
 
-    listing = requests.get(dashboard_url + "/server/WPS/", timeout=30)
+    listing = dashboard.get(dashboard_url + "/server/WPS/", timeout=30)
     assert listing.status_code == 200, listing.text[:1000]
     pks = re.findall(r"/server/WPS/(\d+)/", listing.text)
     assert pks, listing.text[:1000]
     return max(int(p) for p in pks)
 
 
-def test_dashboard_server_list_renders_a_registered_server(registered_wps_server,
+def test_dashboard_server_list_renders_a_registered_server(dashboard, registered_wps_server,
                                                            dashboard_url, wps_url):
     """The row template must reverse every URL name it references."""
-    r = requests.get(dashboard_url + "/server/WPS/", timeout=30)
+    r = dashboard.get(dashboard_url + "/server/WPS/", timeout=30)
     assert r.status_code == 200, r.text[:1000]
     assert wps_url in r.text
 
 
-def test_dashboard_lists_wps_processes(registered_wps_server, dashboard_url):
-    r = requests.get("%s/server/WPS/%d/element/" % (dashboard_url, registered_wps_server),
+def test_dashboard_lists_wps_processes(dashboard, registered_wps_server, dashboard_url):
+    r = dashboard.get("%s/server/WPS/%d/element/" % (dashboard_url, registered_wps_server),
                      timeout=120)
     assert r.status_code == 200, r.text[:1000]
     assert "annual_water_yield" in r.text, r.text[:1000]
 
 
-def test_generated_form_renders_for_every_process(registered_wps_server,
+def test_generated_form_renders_for_every_process(dashboard, registered_wps_server,
                                                   dashboard_url, wps_url):
     """Every advertised process must produce a job form.
 
@@ -80,7 +80,7 @@ def test_generated_form_renders_for_every_process(registered_wps_server,
 
     broken = []
     for process_id in ids:
-        r = requests.get("%s/server/%d/execute/%s/" % (dashboard_url,
+        r = dashboard.get("%s/server/%d/execute/%s/" % (dashboard_url,
                                                        registered_wps_server,
                                                        process_id), timeout=120)
         if r.status_code != 200:
@@ -88,14 +88,14 @@ def test_generated_form_renders_for_every_process(registered_wps_server,
     assert not broken, broken
 
 
-def test_generated_form_offers_registered_data(registered_wps_server, dashboard_url):
+def test_generated_form_offers_registered_data(dashboard, registered_wps_server, dashboard_url):
     """Spatial inputs become dropdowns of registered sources, not free text.
 
     This is what the hand-built water yield form did for one model; the
     generated form derives it for all of them from the InVEST type the WPS
     publishes on each input.
     """
-    r = requests.get("%s/server/%d/execute/annual_water_yield/"
+    r = dashboard.get("%s/server/%d/execute/annual_water_yield/"
                      % (dashboard_url, registered_wps_server), timeout=120)
     assert r.status_code == 200, r.text[:1000]
     # lulc_path is a raster input, so it must render as a select
@@ -103,36 +103,36 @@ def test_generated_form_offers_registered_data(registered_wps_server, dashboard_
 
 
 @pytest.fixture(scope="module")
-def registered_template(dashboard_url, wps_url):
+def registered_template(dashboard, dashboard_url, wps_url):
     """A Templates source pointing at the same WPS, returning its primary key."""
-    r = requests.get("%s/server/TPL/register/Smoke Template/url/%s"
+    r = dashboard.get("%s/server/TPL/register/Smoke Template/url/%s"
                      % (dashboard_url, wps_url), timeout=60)
     assert r.status_code == 200, r.text[:500]
 
-    listing = requests.get(dashboard_url + "/server/TPL/", timeout=30)
+    listing = dashboard.get(dashboard_url + "/server/TPL/", timeout=30)
     assert listing.status_code == 200, listing.text[:1000]
     pks = re.findall(r"/server/TPL/(\d+)/", listing.text)
     assert pks, listing.text[:1000]
     return max(int(p) for p in pks)
 
 
-def test_dashboard_has_a_templates_section(registered_template, dashboard_url):
-    r = requests.get(dashboard_url + "/", timeout=30)
+def test_dashboard_has_a_templates_section(dashboard, registered_template, dashboard_url):
+    r = dashboard.get(dashboard_url + "/", timeout=30)
     assert r.status_code == 200, r.text[:500]
     assert "Templates" in r.text
     # Templates are also ServerWPS rows; they must not show up twice.
-    wps_list = requests.get(dashboard_url + "/server/WPS/", timeout=30)
+    wps_list = dashboard.get(dashboard_url + "/server/WPS/", timeout=30)
     assert "Smoke Template" not in wps_list.text, wps_list.text[:1000]
 
 
-def test_template_lists_the_same_processes(registered_template, dashboard_url):
-    r = requests.get("%s/server/TPL/%d/element/" % (dashboard_url, registered_template),
+def test_template_lists_the_same_processes(dashboard, registered_template, dashboard_url):
+    r = dashboard.get("%s/server/TPL/%d/element/" % (dashboard_url, registered_template),
                      timeout=120)
     assert r.status_code == 200, r.text[:1000]
     assert "annual_water_yield" in r.text
 
 
-def test_template_process_detail_and_its_new_job_link(registered_template,
+def test_template_process_detail_and_its_new_job_link(dashboard, registered_template,
                                                       dashboard_url):
     """Walk the click-through: template -> process -> new job.
 
@@ -140,7 +140,7 @@ def test_template_process_detail_and_its_new_job_link(registered_template,
     detail page was missed and raised KeyError, so this covers the whole path
     rather than just the list and the form.
     """
-    detail = requests.get("%s/server/TPL/%d/element/annual_water_yield/"
+    detail = dashboard.get("%s/server/TPL/%d/element/annual_water_yield/"
                           % (dashboard_url, registered_template), timeout=120)
     assert detail.status_code == 200, detail.text[:1000]
 
@@ -150,7 +150,7 @@ def test_template_process_detail_and_its_new_job_link(registered_template,
         in detail.text, detail.text[:2000]
 
 
-def test_template_form_is_prefilled_from_the_sample_datastack(registered_template,
+def test_template_form_is_prefilled_from_the_sample_datastack(dashboard, registered_template,
                                                               registered_wps_server,
                                                               dashboard_url):
     """A template's job form arrives carrying InVEST's own sample arguments.
@@ -159,18 +159,18 @@ def test_template_form_is_prefilled_from_the_sample_datastack(registered_templat
     data being published: annual_water_yield's datastack sets results_suffix to
     "gura" and seasonality_constant to 5. The plain WPS source must stay empty.
     """
-    tpl = requests.get("%s/server/%d/execute/annual_water_yield/"
+    tpl = dashboard.get("%s/server/%d/execute/annual_water_yield/"
                        % (dashboard_url, registered_template), timeout=120)
     assert tpl.status_code == 200, tpl.text[:1000]
     assert 'value="gura"' in tpl.text, tpl.text[:2000]
 
-    plain = requests.get("%s/server/%d/execute/annual_water_yield/"
+    plain = dashboard.get("%s/server/%d/execute/annual_water_yield/"
                          % (dashboard_url, registered_wps_server), timeout=120)
     assert plain.status_code == 200, plain.text[:1000]
     assert 'value="gura"' not in plain.text
 
 
-def test_generated_form_offers_upload_and_destinations(registered_wps_server,
+def test_generated_form_offers_upload_and_destinations(dashboard, registered_wps_server,
                                                       dashboard_url):
     """The wrapper's own inputs render as a checkbox and server pickers.
 
@@ -178,7 +178,7 @@ def test_generated_form_offers_upload_and_destinations(registered_wps_server,
     render as a text box; the useful destinations are the servers already
     registered, so they are choices.
     """
-    r = requests.get("%s/server/%d/execute/carbon/" % (dashboard_url,
+    r = dashboard.get("%s/server/%d/execute/carbon/" % (dashboard_url,
                                                        registered_wps_server),
                      timeout=120)
     assert r.status_code == 200, r.text[:1000]
@@ -217,9 +217,9 @@ def _write_shared_table(relative_path, content):
         handle.write(content)
 
 
-def _demo_template_pk(dashboard_url):
+def _demo_template_pk(session, dashboard_url):
     """The pk of the demo Templates source, or None if the demo is not loaded."""
-    templates = requests.get(dashboard_url + "/server/TPL/", timeout=30).text
+    templates = session.get(dashboard_url + "/server/TPL/", timeout=30).text
     template_pk = None
     for row in re.findall(r"<tr>(.*?)</tr>", templates, re.S):
         if "InVEST Demo" not in row:
@@ -298,7 +298,7 @@ def _await_job(session, dashboard_url, job_pk, tries=60):
     return None, status
 
 
-def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
+def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard, dashboard_url):
     """anticipated -> Local Pending -> published -> registered, for all three kinds.
 
     Driven through the Templates source so the model arguments are InVEST's own
@@ -309,11 +309,11 @@ def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
     annual_water_yield rather than carbon because it emits rasters, vectors and
     tables, so every destination kind is exercised in one run.
     """
-    template_pk = _demo_template_pk(dashboard_url)
+    template_pk = _demo_template_pk(dashboard, dashboard_url)
     if template_pk is None:
         pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
 
-    session = requests.Session()
+    session = dashboard
     job_pk, destinations = _submit_template_job(session, dashboard_url, template_pk,
                                                 "annual_water_yield")
 
@@ -366,24 +366,24 @@ def test_upload_round_trip_moves_outputs_to_their_destinations(dashboard_url):
     # The table is a genuine upload, not a pointer at where it already sat: it
     # is fetchable from the file server it was registered against.
     table = re.search(r"results/[A-Za-z0-9_]+\.csv", registered["CSV"]).group(0)
-    fetched = requests.get("%s/%s" % (os.environ.get(
+    fetched = dashboard.get("%s/%s" % (os.environ.get(
         "FILESERVER_URL", "http://localhost:8001"), table), timeout=60)
     assert fetched.status_code == 200, fetched.status_code
     assert fetched.text.splitlines()[0].count(",") >= 1, fetched.text[:200]
 
 
-def test_dashboard_wps_process_detail(registered_wps_server, dashboard_url):
+def test_dashboard_wps_process_detail(dashboard, registered_wps_server, dashboard_url):
     """Describes a process through owslib -- the path that raised
     TypeError: WebProcessingService.__init__() got an unexpected keyword
     argument 'verbose' once owslib dropped that parameter."""
-    r = requests.get(
+    r = dashboard.get(
         "%s/server/WPS/%d/element/annual_water_yield/" % (dashboard_url,
                                                           registered_wps_server),
         timeout=120)
     assert r.status_code == 200, r.text[:1000]
 
 
-def test_generated_form_enforces_the_declared_range(registered_wps_server,
+def test_generated_form_enforces_the_declared_range(dashboard, registered_wps_server,
                                                     dashboard_url):
     """A value the model would reject is rejected by the form.
 
@@ -391,7 +391,7 @@ def test_generated_form_enforces_the_declared_range(registered_wps_server,
     range; annual_water_yield's seasonality constant must exceed 0, so 0 is too.
     Both bounds come from the WPS, not from anything hard-coded here.
     """
-    ratio = requests.get("%s/server/%d/execute/forest_carbon_edge_effect/"
+    ratio = dashboard.get("%s/server/%d/execute/forest_carbon_edge_effect/"
                          % (dashboard_url, registered_wps_server), timeout=120)
     assert ratio.status_code == 200, ratio.text[:1000]
     field = re.search(r'<input[^>]*name="biomass_to_carbon_conversion_factor"[^>]*>',
@@ -402,7 +402,7 @@ def test_generated_form_enforces_the_declared_range(registered_wps_server,
 
     # An exclusive bound has no HTML equivalent, so it is nudged one step: the
     # smallest accepted value is just above 0, not 0 itself.
-    exclusive = requests.get("%s/server/%d/execute/annual_water_yield/"
+    exclusive = dashboard.get("%s/server/%d/execute/annual_water_yield/"
                              % (dashboard_url, registered_wps_server), timeout=120)
     field = re.search(r'<input[^>]*name="seasonality_constant"[^>]*>',
                       exclusive.text)
@@ -410,7 +410,7 @@ def test_generated_form_enforces_the_declared_range(registered_wps_server,
     assert 'min="1e-09"' in field.group(0), field.group(0)
 
 
-def test_unique_run_does_not_overwrite_the_previous_runs_outputs(dashboard_url):
+def test_unique_run_does_not_overwrite_the_previous_runs_outputs(dashboard, dashboard_url):
     """Running a job twice with the flag set leaves both runs' results in place.
 
     Output filenames -- and so the layer names they are published under -- derive
@@ -418,11 +418,11 @@ def test_unique_run_does_not_overwrite_the_previous_runs_outputs(dashboard_url):
     over the first. With the flag, each run adds its own token and both sets of
     layers survive.
     """
-    template_pk = _demo_template_pk(dashboard_url)
+    template_pk = _demo_template_pk(dashboard, dashboard_url)
     if template_pk is None:
         pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
 
-    session = requests.Session()
+    session = dashboard
     job_pk, destinations = _submit_template_job(
         session, dashboard_url, template_pk, "annual_water_yield",
         extra={"esws_unique_run": "on"})
@@ -463,16 +463,16 @@ def test_unique_run_does_not_overwrite_the_previous_runs_outputs(dashboard_url):
     assert len(second - before) == 2, (before, second)
 
 
-def test_change_detection_distinguishes_changed_from_unchanged(dashboard_url):
+def test_change_detection_distinguishes_changed_from_unchanged(dashboard, dashboard_url):
     """Fingerprint a table, rewrite it, and see only that one reported changed.
 
     Uses the writable results share, since the sample data is mounted read-only:
     a check has to be able to observe an actual change, not just run.
     """
-    if _demo_template_pk(dashboard_url) is None:
+    if _demo_template_pk(dashboard, dashboard_url) is None:
         pytest.skip("needs the demo loaded (make demo): no registered sources")
 
-    servers = requests.get(dashboard_url + "/server/CSV/", timeout=30).text
+    servers = dashboard.get(dashboard_url + "/server/CSV/", timeout=30).text
     pk = None
     for row in re.findall(r"<tr>(.*?)</tr>", servers, re.S):
         if "Local Pending" in row:
@@ -483,7 +483,7 @@ def test_change_detection_distinguishes_changed_from_unchanged(dashboard_url):
     assert pk, servers[:1000]
 
     def check():
-        page = requests.get("%s/server/CSV/%d/check/" % (dashboard_url, pk),
+        page = dashboard.get("%s/server/CSV/%d/check/" % (dashboard_url, pk),
                             timeout=900).text
         tally = dict(zip(("changed", "unchanged", "unreachable"),
                          (int(n) for n in re.findall(
@@ -507,7 +507,7 @@ def test_change_detection_distinguishes_changed_from_unchanged(dashboard_url):
     # test is about.
     probe = "results/change_probe_%s.csv" % uuid.uuid4().hex[:8]
     _write_shared_table(probe, "lucode,root_depth\n1,1000\n")
-    requests.get("%s/server/CSV/%d/register/%s/"
+    dashboard.get("%s/server/CSV/%d/register/%s/"
                  % (dashboard_url, pk, quote(probe, safe="")), timeout=60)
 
     first, _ = check()
@@ -524,7 +524,7 @@ def test_change_detection_distinguishes_changed_from_unchanged(dashboard_url):
     assert third["changed"] == 0, third
 
 
-def test_change_detection_reports_unreachable_rather_than_unchanged(dashboard_url):
+def test_change_detection_reports_unreachable_rather_than_unchanged(dashboard, dashboard_url):
     """Data that cannot be fetched must not be counted as data that has not changed.
 
     Driven by registering an element that points at nothing, rather than by
@@ -532,11 +532,11 @@ def test_change_detection_reports_unreachable_rather_than_unchanged(dashboard_ur
     that CRS identification handles unnamed datums and the MODIS grid, so the
     distinction has to be provoked deliberately to stay tested.
     """
-    if _demo_template_pk(dashboard_url) is None:
+    if _demo_template_pk(dashboard, dashboard_url) is None:
         pytest.skip("needs the demo loaded (make demo): no registered sources")
 
-    session = requests.Session()
-    servers = requests.get(dashboard_url + "/server/CSV/", timeout=30).text
+    session = dashboard
+    servers = dashboard.get(dashboard_url + "/server/CSV/", timeout=30).text
     pk = None
     for row in re.findall(r"<tr>(.*?)</tr>", servers, re.S):
         if "Local Pending" in row:
@@ -561,24 +561,24 @@ def test_change_detection_reports_unreachable_rather_than_unchanged(dashboard_ur
     assert unchanged > 0, "the reachable tables should still report unchanged"
 
 
-def test_a_reactive_job_reruns_when_its_input_changes(dashboard_url):
+def test_a_reactive_job_reruns_when_its_input_changes(dashboard, dashboard_url):
     """The whole point of #3: change the data a finished job used, and it runs again.
 
     The job is pointed at a copy of one of its own sample tables, placed on the
     writable share, because the sample data is mounted read-only and a job whose
     inputs cannot change cannot demonstrate reacting to a change.
     """
-    template_pk = _demo_template_pk(dashboard_url)
+    template_pk = _demo_template_pk(dashboard, dashboard_url)
     if template_pk is None:
         pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
 
-    session = requests.Session()
+    session = dashboard
 
     # A copy of the model's own biophysical table, so the run is still valid.
     # Fetched over HTTP rather than read from disk: the samples are mounted at
     # different paths in the wps and fileserver containers.
     fileserver = os.environ.get("FILESERVER_URL", "http://localhost:8001")
-    source = requests.get(
+    source = dashboard.get(
         fileserver + "/invest/Annual_Water_Yield/biophysical_table_gura.csv",
         timeout=60)
     assert source.status_code == 200, source.status_code
@@ -586,7 +586,7 @@ def test_a_reactive_job_reruns_when_its_input_changes(dashboard_url):
     probe = "results/reactive_biophysical.csv"
     _write_shared_table(probe, original)
 
-    csv_servers = requests.get(dashboard_url + "/server/CSV/", timeout=30).text
+    csv_servers = dashboard.get(dashboard_url + "/server/CSV/", timeout=30).text
     csv_pk = None
     for row in re.findall(r"<tr>(.*?)</tr>", csv_servers, re.S):
         if "Local Pending" in row:
@@ -655,32 +655,32 @@ def test_a_reactive_job_reruns_when_its_input_changes(dashboard_url):
     assert "unchanged" in everything, everything[:1500]
 
 
-def test_the_job_graph_page_and_its_bpmn_export(dashboard_url):
+def test_the_job_graph_page_and_its_bpmn_export(dashboard, dashboard_url):
     """The pipeline view renders, and its BPMN export is well-formed BPMN.
 
     Schema validation lives in the unit tests; here the point is that the view
     reaches the builder at all and hands back the right content type.
     """
-    page = requests.get(dashboard_url + "/job/graph/", timeout=180)
+    page = dashboard.get(dashboard_url + "/job/graph/", timeout=180)
     assert page.status_code == 200, page.text[:1000]
     assert "flowchart LR" in page.text, page.text[:1500]
     assert "job" in page.text
 
-    export = requests.get(dashboard_url + "/job/graph.bpmn", timeout=180)
+    export = dashboard.get(dashboard_url + "/job/graph.bpmn", timeout=180)
     assert export.status_code == 200, export.status_code
     assert export.headers["Content-Type"].startswith("application/xml")
     assert "esws-pipeline.bpmn" in export.headers.get("Content-Disposition", "")
     assert "bpmn" in export.text[:400].lower(), export.text[:400]
 
 
-def test_a_published_output_records_which_job_made_it(dashboard_url):
+def test_a_published_output_records_which_job_made_it(dashboard, dashboard_url):
     """The edge in the pipeline graph comes from this: without provenance a
     registered element is just a layer nobody claims."""
-    template_pk = _demo_template_pk(dashboard_url)
+    template_pk = _demo_template_pk(dashboard, dashboard_url)
     if template_pk is None:
         pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
 
-    session = requests.Session()
+    session = dashboard
     job_pk, _destinations = _submit_template_job(session, dashboard_url,
                                                  template_pk, "annual_water_yield")
     session.get("%s/job/%d/run/" % (dashboard_url, job_pk), timeout=180)
@@ -692,7 +692,7 @@ def test_a_published_output_records_which_job_made_it(dashboard_url):
     assert "job%d" % job_pk in graph, graph[:1500]
 
 
-def test_the_template_form_fills_every_required_field(dashboard_url):
+def test_the_template_form_fills_every_required_field(dashboard, dashboard_url):
     """A Templates job must be submittable without typing anything.
 
     sdr is the case worth pinning: its ic_0_param is the only field in the demo
@@ -700,11 +700,11 @@ def test_the_template_form_fills_every_required_field(dashboard_url):
     silently -- the form then re-renders complaining that a required value is
     missing, which reads like the prefill is broken when it is not.
     """
-    template_pk = _demo_template_pk(dashboard_url)
+    template_pk = _demo_template_pk(dashboard, dashboard_url)
     if template_pk is None:
         pytest.skip("needs the demo loaded (make demo): no InVEST Demo template")
 
-    page = requests.get("%s/server/%d/execute/sdr/" % (dashboard_url, template_pk),
+    page = dashboard.get("%s/server/%d/execute/sdr/" % (dashboard_url, template_pk),
                         timeout=180).text
 
     numeric = re.search(r'<input[^>]*name="ic_0_param"[^>]*>', page)

--- a/tools/wpsclient/website/settings.py
+++ b/tools/wpsclient/website/settings.py
@@ -47,6 +47,12 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # Every view requires a login unless it says otherwise with
+    # @login_not_required. Default-deny rather than 60-odd @login_required
+    # decorators: the failure mode of a forgotten decorator is a view that
+    # quietly serves another user's data, and the failure mode of a forgotten
+    # exemption is a login prompt somebody reports on the first day.
+    'django.contrib.auth.middleware.LoginRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -60,6 +66,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
+                'wpsclient.context_processors.roles',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
@@ -130,3 +137,10 @@ STATIC_URL = '/static/'
 
 # Django 3.2+ requires an explicit default primary key type.
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Login. django.contrib.auth.urls supplies the views; only the destinations are
+# ours. LOGOUT_REDIRECT_URL points back at the login page rather than the
+# dashboard, which LoginRequiredMiddleware would only bounce straight back.
+LOGIN_URL = 'login'
+LOGIN_REDIRECT_URL = 'dashboard'
+LOGOUT_REDIRECT_URL = 'login'

--- a/tools/wpsclient/website/urls.py
+++ b/tools/wpsclient/website/urls.py
@@ -18,5 +18,9 @@ from django.contrib import admin
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    # login/logout/password views. Ahead of the wpsclient catch-all, whose
+    # first pattern is r'^$' but whose later ones are broad enough to shadow
+    # these if they came second.
+    url(r'^accounts/', include('django.contrib.auth.urls')),
     url(r'', include('wpsclient.urls'))
 ]

--- a/tools/wpsclient/wpsclient/context_processors.py
+++ b/tools/wpsclient/wpsclient/context_processors.py
@@ -1,0 +1,14 @@
+"""Template context every page needs.
+
+`is_admin` is asked for in the page header and wherever a control is shown only
+to administrators. Supplying it here rather than from each view keeps the answer
+identical everywhere and keeps templates from reproducing the rule as
+`user.is_staff or user.is_superuser`, which would then have to be found and
+changed if the rule moved.
+"""
+from . import scope
+
+
+def roles(request):
+    return {"is_admin": scope.is_admin(getattr(request, "user", None))
+            if hasattr(request, "user") else False}

--- a/tools/wpsclient/wpsclient/models.py
+++ b/tools/wpsclient/wpsclient/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 # Create your models here.
@@ -182,6 +183,74 @@ class ElementProvenance(models.Model):
 
     def __str__(self):
         return "%s <- job %s" % (self.element.identifier, self.job_id)
+
+
+class Ownership(models.Model):
+    """Who created a row, and whether everyone else may see it.
+
+    Its own table per owned type rather than columns on Server/ServerElement/Job,
+    for the same reason as ElementFingerprint and ElementProvenance: this app has
+    migrations disabled (MIGRATION_MODULES) and its tables come from
+    `migrate --run-syncdb`, which creates a missing table but cannot add a column
+    to one that already exists.
+
+    That constraint applies to these tables too, once they exist. A field added
+    here later would need yet another table, so the ones below are the fields the
+    scoping rules need, decided in one pass:
+
+      user       -- the owner. Deleting the user deletes the claim, which leaves
+                    the row unowned, and an unowned row is admin-only.
+      is_public  -- opt-in visibility for everyone else. Default False: a row is
+                    private unless someone says otherwise, so a new kind of
+                    object cannot leak by forgetting to set this.
+      created_at -- when it was claimed, not when the row was made.
+
+    Abstract, so each owned type gets its own table with all of these columns
+    rather than one shared table keyed by content type: a OneToOneField gives the
+    database the uniqueness constraint that "one owner per row" needs, and
+    generic relations cannot be filtered across a join the way scoping needs.
+    """
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    is_public = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return "%s (%s)" % (self.user, "public" if self.is_public else "private")
+
+
+class ServerOwner(Ownership):
+    """OneToOne against Server, the multi-table parent, so a claim on a
+    ServerCSV/WCS/WFS/WPS/Template is the same row -- the subclasses share the
+    parent's primary key, and scoping filters traverse the parent relation."""
+
+    server = models.OneToOneField(Server, on_delete=models.CASCADE,
+                                  related_name="ownership")
+
+
+class ElementOwner(Ownership):
+    """OneToOne against ServerElement, the multi-table parent. See ServerOwner.
+
+    An element also inherits visibility from the job that produced it -- see
+    ElementProvenance and wpsclient.scope.visible_elements -- so a public job
+    exposes its outputs without each one being toggled individually.
+    """
+
+    element = models.OneToOneField(ServerElement, on_delete=models.CASCADE,
+                                   related_name="ownership")
+
+
+class JobOwner(Ownership):
+    """OneToOne against Job. Setting is_public here also publishes the job's
+    outputs, via the ElementProvenance edge rather than by copying the flag onto
+    each element: the outputs of a run are not independently owned, and a
+    duplicated flag would drift the first time one side was updated alone."""
+
+    job = models.OneToOneField(Job, on_delete=models.CASCADE,
+                               related_name="ownership")
 
 ##class WCS_Instance(models.Model):
 ##    server = models.ForeignKey(WCS_Server, on_delete=models.CASCADE)   

--- a/tools/wpsclient/wpsclient/scope.py
+++ b/tools/wpsclient/wpsclient/scope.py
@@ -1,0 +1,122 @@
+"""Who may see which rows.
+
+Every visibility rule in the dashboard lives here rather than in the 60-odd
+views, so that "what can this user see" has one answer that can be read in one
+place and tested on its own. A view that filters its own queryset by hand is a
+view that can be forgotten when the rules change.
+
+The rules:
+
+  admin       -- sees everything, exactly as the dashboard behaved before there
+                 were users at all.
+  owner       -- sees what they created.
+  public      -- anyone logged in sees a row whose owner marked it public.
+  job outputs -- an element produced by a public job is public, without being
+                 toggled itself. The edge already exists (ElementProvenance),
+                 so this is a join and not a copied flag.
+  unowned     -- admin-only. Rows that predate ownership match none of the
+                 clauses below, so they fall out of every user query without a
+                 special case. That is deliberate: the alternative, treating
+                 them as public, would expose one person's history to everyone
+                 the moment logins were switched on.
+"""
+from django.db.models import Q
+
+from .models import Job, Server, ServerElement
+
+
+def is_admin(user):
+    """Admins are Django staff/superusers.
+
+    Kept as a function rather than inlined so there is one definition to change
+    if admin ever comes from somewhere else (a group, or an external role
+    service) -- the views and templates all ask this question through here.
+    """
+    return bool(user.is_authenticated and (user.is_staff or user.is_superuser))
+
+
+def _restrict(queryset, user, extra=None):
+    """Owned-by-user OR public, plus any model-specific clause."""
+    if is_admin(user):
+        return queryset
+    if not user.is_authenticated:
+        return queryset.none()
+    visible = Q(ownership__user=user) | Q(ownership__is_public=True)
+    if extra is not None:
+        visible |= extra
+    # distinct(): the provenance clause joins through a second table, which can
+    # repeat a row that matches on more than one branch.
+    return queryset.filter(visible).distinct()
+
+
+def visible_servers(user, queryset=None):
+    return _restrict(Server.objects.all() if queryset is None else queryset, user)
+
+
+def visible_jobs(user, queryset=None):
+    return _restrict(Job.objects.all() if queryset is None else queryset, user)
+
+
+def visible_elements(user, queryset=None):
+    """Owned, public, or produced by a public job."""
+    return _restrict(
+        ServerElement.objects.all() if queryset is None else queryset, user,
+        extra=Q(provenance__job__ownership__is_public=True))
+
+
+def owns(user, instance):
+    """True when this user claimed the row. Admins are not owners -- they can
+    see and administer everything, but "who made this" stays a fact about the
+    user who made it."""
+    ownership = getattr(instance, "ownership", None)
+    return bool(ownership and user.is_authenticated
+                and ownership.user_id == user.pk)
+
+
+def may_modify(user, instance):
+    """Editing, deleting, running, or changing what is public.
+
+    An unowned row is modifiable only by an admin, which matches it being
+    visible only to an admin.
+    """
+    return is_admin(user) or owns(user, instance)
+
+
+def claim(instance, user, is_public=False):
+    """Record who created a row. Idempotent: re-registering something already
+    claimed leaves the original owner in place rather than transferring it."""
+    from .models import ElementOwner, JobOwner, ServerOwner
+
+    owner_model = {Server: ServerOwner,
+                   ServerElement: ElementOwner,
+                   Job: JobOwner}[_owned_base(instance)]
+    field = {ServerOwner: "server",
+             ElementOwner: "element",
+             JobOwner: "job"}[owner_model]
+
+    if user is None or not user.is_authenticated:
+        return None
+    owner, _created = owner_model.objects.get_or_create(
+        defaults={"user": user, "is_public": is_public},
+        **{field: _owned_base_instance(instance)})
+    return owner
+
+
+def _owned_base(instance):
+    """The multi-table parent an ownership row points at.
+
+    ServerCSV and ElementWPS are subclasses; the claim is recorded against
+    Server / ServerElement so one row covers the object whichever subclass it is
+    read back as.
+    """
+    for base in (Server, ServerElement, Job):
+        if isinstance(instance, base):
+            return base
+    raise TypeError("not an ownable model: %r" % (instance,))
+
+
+def _owned_base_instance(instance):
+    base = _owned_base(instance)
+    if isinstance(instance, base) and type(instance) is not base:
+        return base.objects.get(pk=instance.pk)
+    return instance

--- a/tools/wpsclient/wpsclient/templates/registration/login.html
+++ b/tools/wpsclient/wpsclient/templates/registration/login.html
@@ -1,0 +1,34 @@
+{% extends "wpsclient/base.html" %}
+
+{% comment %}
+Lives under registration/ rather than wpsclient/ because that is where
+django.contrib.auth.views.LoginView looks for it.
+{% endcomment %}
+
+{% block content %}
+  <h2>Sign in</h2>
+
+  {% if form.errors %}
+    <p><strong>That username and password did not match. Please try again.</strong></p>
+  {% endif %}
+
+  {% if next and user.is_authenticated %}
+    <p>Your account does not have access to that page. Sign in as a user that does.</p>
+  {% endif %}
+
+  <form method="post" action="{% url 'login' %}">
+    {% csrf_token %}
+    <table>
+      <tr>
+        <td>{{ form.username.label_tag }}</td>
+        <td>{{ form.username }}</td>
+      </tr>
+      <tr>
+        <td>{{ form.password.label_tag }}</td>
+        <td>{{ form.password }}</td>
+      </tr>
+    </table>
+    <input type="submit" value="Sign in">
+    <input type="hidden" name="next" value="{{ next }}">
+  </form>
+{% endblock %}

--- a/tools/wpsclient/wpsclient/templates/wpsclient/base.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/base.html
@@ -4,6 +4,16 @@
 <body>
         <div class="page-header">
             <h1><a href="/">ESWS Client</a></h1>
+            {% if user.is_authenticated %}
+              <p>
+                Signed in as <strong>{{ user.get_username }}</strong>{% if is_admin %}
+                (admin &mdash; seeing every user's servers, elements and jobs){% endif %}.
+                <form action="{% url 'logout' %}" method="post" style="display:inline">
+                  {% csrf_token %}
+                  <button type="submit">Sign out</button>
+                </form>
+              </p>
+            {% endif %}
         </div>
         <div class="content container">
             <div class="row">

--- a/tools/wpsclient/wpsclient/templates/wpsclient/job_detail.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/job_detail.html
@@ -2,13 +2,25 @@
 
 {% block content %}
     <div class="server">
-	{% if user.is_authenticated %}
-        <a class="btn btn-default" href="{% url 'process_edit' process_pk=job.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
+	{% if may_modify %}
+        {# 'process_edit' until logins existed: this branch was unreachable, since
+           user.is_authenticated was always false, so the stale URL name never
+           raised. It is job_edit, and it is shown to whoever may actually edit. #}
+        <a class="btn btn-default" href="{% url 'job_edit' job_pk=job.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
 	{% endif %}
         <p><b>Server: </b><a href="{% url 'server_element_list' server_type='WPS' server_pk=job.server.pk %}">{{ job.server.title }}</a></p>
         <p><b>Process: </b><a href="{% url 'server_element_detail' server_type='WPS' server_pk=job.server.pk element_id=job.identifier %}">{{ job.identifier }}</a></p>        
         <p><b>Job Id: </b>{{job.pk}}<p/>
         <p><b>Status: </b>{{job.status}}</p>
+        <p><b>Visibility: </b>{% if is_public %}Public{% else %}Private{% endif %}
+        {% if may_modify %}
+          <form action="{% url 'job_visibility' job_pk=job.pk %}" method="post" style="display:inline">
+            {% csrf_token %}
+            <button type="submit">Make {% if is_public %}private{% else %}public{% endif %}</button>
+          </form>
+          &mdash; a public job also publishes every output it produced
+        {% endif %}
+        </p>
         <p><b><a href="{% url 'job_edit' job_pk=job.pk %}">Edit Job</a></b></p>
         {% if reactive %}
         <p><b><a href="{% url 'job_react' job_pk=job.pk %}">Check inputs and re-run if changed</a></b></p>

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_detail.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_detail.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="server">
 	{% if user.is_authenticated %}
-        <a class="btn btn-default" href="{% url 'server_edit' server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
+        <a class="btn btn-default" href="{% url 'server_edit' server_type=server.server_type server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
 	{% endif %}
 <h2>{{ server.server_type }} Source</h2>
 
@@ -19,6 +19,18 @@
 
 </table>
 <a href="{% url 'server_edit' server_type=server.server_type server_pk=server.pk %}">Edit</a>
+
+<p><b>Visibility: </b>{% if is_public %}Public{% else %}Private{% endif %}
+{% if may_modify %}
+  <form action="{% url 'server_visibility' server_type=server.server_type server_pk=server.pk %}" method="post" style="display:inline">
+    {% csrf_token %}
+    <button type="submit">Make {% if is_public %}private{% else %}public{% endif %}</button>
+  </form>
+  &mdash; a public source is one everyone can list processes from and register
+  against. It does not publish the elements already registered on it; those
+  carry their own toggle.
+{% endif %}
+</p>
     </div>
 
 <table border=1 frame=void rules=all>
@@ -29,10 +41,14 @@
 <td><center>Server Title</center></td>
 <td width=50%><center>JSON Parameters</center></td></tr>
 {% for p in process_list  %}
-<tr><td><center><a href="{% url 'job_detail' process_pk=p.pk %}">{{ p.pk }}</a></center></td>
+{# job_detail takes job_pk, and neither server_describe_process nor
+   server_capabilities is a route -- this loop only renders when a server has
+   jobs, which is why three dead URL names survived here. job_detail.html
+   already links the same two things by their real names. #}
+<tr><td><center><a href="{% url 'job_detail' job_pk=p.pk %}">{{ p.pk }}</a></center></td>
 <td>{{ p.status }}</td>
-<td><a href="{% url 'server_describe_process' server_pk=p.server.pk process_id=p.identifier %}">{{ p.identifier }}</a></td>
-<td><center><a href="{% url 'server_capabilities' server_pk=p.server.pk %}">{{ p.server.pk }}</a><center></td>
+<td><a href="{% url 'server_element_detail' server_type='WPS' server_pk=p.server.pk element_id=p.identifier %}">{{ p.identifier }}</a></td>
+<td><center><a href="{% url 'server_element_list' server_type='WPS' server_pk=p.server.pk %}">{{ p.server.pk }}</a><center></td>
 <td>{{ p.server.title }}</td>
 <td width=50%>{{ p.args }}</td></tr>
 {% endfor %}

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_element_list.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_element_list.html
@@ -20,15 +20,27 @@
 <tr>
 <td>Action</td>
 <td>Id</td>
+<td>Visibility</td>
 {% if checkable %}<td>Last checked</td><td>Last changed</td>{% endif %}
 </tr>
-{% for element, state in registered_rows %}
+{% for row in registered_rows %}
 <tr>
-<td><a href="{% url 'server_element_unregister' server_type=server.server_type server_pk=server.pk element_id=element %}">Unbookmark</a></td>
-<td><a href="{% url 'server_element_detail' server_type=server.server_type server_pk=server.pk element_id=element %}">{{element}}</td>
+<td><a href="{% url 'server_element_unregister' server_type=server.server_type server_pk=server.pk element_id=row.identifier %}">Unbookmark</a></td>
+<td><a href="{% url 'server_element_detail' server_type=server.server_type server_pk=server.pk element_id=row.identifier %}">{{row.identifier}}</td>
+<td>
+  {% if row.may_toggle %}
+    <form action="{% url 'element_visibility' server_type=server.server_type server_pk=server.pk element_id=row.identifier %}" method="post" style="display:inline">
+      {% csrf_token %}
+      {# POST, not a link: this changes what other people can see. #}
+      <button type="submit">{% if row.is_public %}Public &mdash; make private{% else %}Private &mdash; make public{% endif %}</button>
+    </form>
+  {% else %}
+    {% if row.is_public %}Public{% else %}Private{% endif %}
+  {% endif %}
+</td>
 {% if checkable %}
-<td>{% if state %}{{ state.checked_at|date:"Y-m-d H:i" }}{% if state.unreachable %} (unreachable){% endif %}{% else %}never{% endif %}</td>
-<td>{% if state.changed_at %}{{ state.changed_at|date:"Y-m-d H:i" }}{% else %}&mdash;{% endif %}</td>
+<td>{% if row.fingerprint %}{{ row.fingerprint.checked_at|date:"Y-m-d H:i" }}{% if row.fingerprint.unreachable %} (unreachable){% endif %}{% else %}never{% endif %}</td>
+<td>{% if row.fingerprint.changed_at %}{{ row.fingerprint.changed_at|date:"Y-m-d H:i" }}{% else %}&mdash;{% endif %}</td>
 {% endif %}
 </tr>
 {% endfor %}

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_capabilities.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_capabilities.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="server">
 	{% if user.is_authenticated %}
-        <a class="btn btn-default" href="{% url 'server_edit' server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
+        <a class="btn btn-default" href="{% url 'server_edit' server_type=server.server_type server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
 	{% endif %}
         <h2>{{ server.title }}</h2>
         <p>{{ server.url|linebreaksbr }}</p>

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_describe_process.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_describe_process.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="server">
 	{% if user.is_authenticated %}
-        <a class="btn btn-default" href="{% url 'server_edit' server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
+        <a class="btn btn-default" href="{% url 'server_edit' server_type=server.server_type server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
 	{% endif %}
         <h2><a href="{% url 'server_element_list' server_type='WPS' server_pk=server.pk %}">{{ server.title }}</a></h2>
         <p><b>URL</b></p><p>{{ server.url}}</p>

--- a/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_elements.html
+++ b/tools/wpsclient/wpsclient/templates/wpsclient/server_wps_elements.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="server">
 	{% if user.is_authenticated %}
-        <a class="btn btn-default" href="{% url 'server_edit' server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
+        <a class="btn btn-default" href="{% url 'server_edit' server_type=server.server_type server_pk=server.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
 	{% endif %}
         <h2>{{ server.title }}</h2>
         <p>{{ server.url|linebreaksbr }}</p>

--- a/tools/wpsclient/wpsclient/tests_scope.py
+++ b/tools/wpsclient/wpsclient/tests_scope.py
@@ -1,0 +1,272 @@
+"""Who can see what, and who can change it.
+
+Runs under Django's test runner against a throwaway database, so it needs
+neither the stack nor GeoServer:
+
+    python tools/wpsclient/manage.py test wpsclient
+
+The scoping rules are one module (wpsclient.scope) precisely so they can be
+tested here rather than inferred from 60-odd views, and the last test checks the
+views really do route through it.
+"""
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import NoReverseMatch, get_resolver, reverse
+from django.urls.resolvers import URLPattern, URLResolver
+
+from . import scope
+from .models import (ElementProvenance, ElementWCS, Job, ServerElement,
+                     ServerWCS, ServerWPS)
+
+
+class ScopeRulesTests(TestCase):
+    """The rules themselves, without going through a view."""
+
+    def setUp(self):
+        self.alice = User.objects.create_user("alice", password="alice-pw")
+        self.bob = User.objects.create_user("bob", password="bob-pw")
+        self.admin = User.objects.create_user("root", password="root-pw",
+                                              is_staff=True, is_superuser=True)
+        self.server = ServerWCS.objects.create(title="s", url="http://s/wcs")
+        self.element = ElementWCS.objects.create(server=self.server,
+                                                 identifier="x")
+
+    def test_an_owned_row_is_visible_only_to_its_owner(self):
+        scope.claim(self.element, self.alice)
+        self.assertIn(self.element.serverelement_ptr,
+                      scope.visible_elements(self.alice))
+        self.assertNotIn(self.element.serverelement_ptr,
+                         scope.visible_elements(self.bob))
+
+    def test_public_is_visible_to_everyone_logged_in(self):
+        scope.claim(self.element, self.alice, is_public=True)
+        self.assertIn(self.element.serverelement_ptr,
+                      scope.visible_elements(self.bob))
+
+    def test_an_unowned_row_is_admin_only(self):
+        """Rows that predate ownership. Admin-only was the chosen policy, and it
+        has to hold without anything special-casing "no ownership row"."""
+        self.assertEqual(list(scope.visible_elements(self.alice)), [])
+        self.assertIn(self.element.serverelement_ptr,
+                      scope.visible_elements(self.admin))
+
+    def test_admin_sees_everything(self):
+        scope.claim(self.element, self.alice)
+        self.assertIn(self.element.serverelement_ptr,
+                      scope.visible_elements(self.admin))
+
+    def test_a_public_job_publishes_the_outputs_it_produced(self):
+        """The rule that is derived rather than copied: an output is public
+        because the job that made it is, through ElementProvenance."""
+        wps = ServerWPS.objects.create(title="w", url="http://w/wps")
+        job = Job.objects.create(server=wps, identifier="carbon")
+        scope.claim(job, self.alice)
+        ElementProvenance.objects.create(
+            element=self.element.serverelement_ptr, job=job)
+        scope.claim(self.element, self.alice)
+
+        # Private job: bob sees neither.
+        self.assertNotIn(job, scope.visible_jobs(self.bob))
+        self.assertNotIn(self.element.serverelement_ptr,
+                         scope.visible_elements(self.bob))
+
+        job.ownership.is_public = True
+        job.ownership.save()
+
+        # Public job: bob sees the job *and* its output, without the element
+        # itself ever being toggled.
+        self.assertIn(job, scope.visible_jobs(self.bob))
+        self.assertIn(self.element.serverelement_ptr,
+                      scope.visible_elements(self.bob))
+        self.assertFalse(self.element.ownership.is_public)
+
+    def test_seeing_a_public_row_is_not_permission_to_change_it(self):
+        scope.claim(self.element, self.alice, is_public=True)
+        self.assertTrue(scope.may_modify(self.alice, self.element))
+        self.assertFalse(scope.may_modify(self.bob, self.element))
+        self.assertTrue(scope.may_modify(self.admin, self.element))
+
+    def test_claiming_twice_does_not_transfer_ownership(self):
+        scope.claim(self.element, self.alice)
+        scope.claim(self.element, self.bob)
+        self.assertEqual(self.element.ownership.user, self.alice)
+
+    def test_anonymous_sees_nothing(self):
+        from django.contrib.auth.models import AnonymousUser
+        scope.claim(self.element, self.alice, is_public=True)
+        self.assertEqual(list(scope.visible_elements(AnonymousUser())), [])
+
+
+class LoginRequiredTests(TestCase):
+    """Every URL the dashboard serves needs a login.
+
+    Enumerated from the urlconf rather than listed by hand: a view added later
+    is covered the day it is added, which is the whole point of putting
+    LoginRequiredMiddleware in front rather than decorating each view. The same
+    check catches an accidental @login_not_required.
+    """
+
+    #: Paths that must stay reachable to a signed-out visitor. Anything not
+    #: here has to redirect to the login page.
+    PUBLIC = {"/accounts/login/"}
+
+    def _urls(self):
+        """One concrete URL per named route, with placeholder arguments.
+
+        Walks the urlconf rather than reverse_dict, whose values are an
+        internal 4-tuple; the pattern objects give the named groups directly.
+        """
+        samples = {"server_type": "WCS", "server_pk": "1", "job_pk": "1",
+                   "element_id": "x", "process_id": "carbon", "args": "e30",
+                   "title": "t", "url": "http://example.invalid/x"}
+
+        def walk(resolver):
+            for entry in resolver.url_patterns:
+                if isinstance(entry, URLResolver):
+                    yield from walk(entry)
+                    continue
+                if not isinstance(entry, URLPattern) or not entry.name:
+                    continue
+                params = list(entry.pattern.regex.groupindex)
+                if any(p not in samples for p in params):
+                    continue
+                try:
+                    yield entry.name, reverse(
+                        entry.name, kwargs={p: samples[p] for p in params})
+                except NoReverseMatch:
+                    continue
+
+        yield from walk(get_resolver())
+
+    def test_every_view_requires_a_login(self):
+        unprotected = []
+        for name, url in self._urls():
+            if url in self.PUBLIC or url.startswith("/admin/") \
+                    or url.startswith("/accounts/"):
+                continue
+            response = self.client.get(url)
+            # 302 to the login page is the pass. A 200 means the view served a
+            # signed-out visitor; anything else at least did not serve data.
+            if response.status_code == 200:
+                unprotected.append("%s (%s)" % (name, url))
+        self.assertEqual(unprotected, [],
+                         "views served without a login: %s" % unprotected)
+
+    def test_the_check_above_can_actually_fail(self):
+        """Guard against a vacuous pass: if _urls() yielded nothing, or every
+        request errored, the test above would pass having checked nothing."""
+        self.assertGreater(len(list(self._urls())), 10)
+
+    def test_login_page_is_reachable_signed_out(self):
+        self.assertEqual(self.client.get("/accounts/login/").status_code, 200)
+
+
+class VisibilityToggleTests(TestCase):
+    """The UI control: POST-only, and owner-or-admin."""
+
+    def setUp(self):
+        self.alice = User.objects.create_user("alice", password="alice-pw")
+        self.bob = User.objects.create_user("bob", password="bob-pw")
+        self.server = ServerWCS.objects.create(title="s", url="http://s/wcs")
+        self.element = ElementWCS.objects.create(server=self.server,
+                                                 identifier="x")
+        scope.claim(self.server, self.alice)
+        scope.claim(self.element, self.alice)
+        self.url = reverse("element_visibility",
+                           kwargs={"server_type": "WCS",
+                                   "server_pk": self.server.pk,
+                                   "element_id": "x"})
+
+    def test_owner_can_publish_and_unpublish(self):
+        self.client.login(username="alice", password="alice-pw")
+        self.client.post(self.url)
+        self.element.refresh_from_db()
+        self.assertTrue(self.element.ownership.is_public)
+
+        self.client.post(self.url)
+        self.element.ownership.refresh_from_db()
+        self.assertFalse(self.element.ownership.is_public)
+
+    def test_get_does_not_toggle(self):
+        """A link, a prefetch or a crawler must not change what is published."""
+        self.client.login(username="alice", password="alice-pw")
+        self.client.get(self.url)
+        self.element.refresh_from_db()
+        self.assertFalse(self.element.ownership.is_public)
+
+    def test_a_stranger_cannot_publish_someone_elses_element(self):
+        self.client.login(username="bob", password="bob-pw")
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 404)
+        self.element.refresh_from_db()
+        self.assertFalse(self.element.ownership.is_public)
+
+    def test_a_reader_of_a_public_element_still_cannot_toggle_it(self):
+        self.element.ownership.is_public = True
+        self.element.ownership.save()
+        self.client.login(username="bob", password="bob-pw")
+        self.assertEqual(self.client.post(self.url).status_code, 404)
+        self.element.ownership.refresh_from_db()
+        self.assertTrue(self.element.ownership.is_public)
+
+
+class ViewScopingTests(TestCase):
+    """The lists really are filtered, not just the helpers."""
+
+    def setUp(self):
+        self.alice = User.objects.create_user("alice", password="alice-pw")
+        self.bob = User.objects.create_user("bob", password="bob-pw")
+        self.wps = ServerWPS.objects.create(title="alice-server",
+                                            url="http://w/wps")
+        scope.claim(self.wps, self.alice)
+        self.job = Job.objects.create(server=self.wps, identifier="carbon")
+        scope.claim(self.job, self.alice)
+
+    def test_dashboard_hides_another_users_servers_and_jobs(self):
+        self.client.login(username="bob", password="bob-pw")
+        body = self.client.get(reverse("dashboard")).content.decode()
+        self.assertNotIn("alice-server", body)
+
+    def test_dashboard_shows_your_own(self):
+        self.client.login(username="alice", password="alice-pw")
+        body = self.client.get(reverse("dashboard")).content.decode()
+        self.assertIn("alice-server", body)
+
+    def test_job_detail_is_404_for_a_stranger(self):
+        self.client.login(username="bob", password="bob-pw")
+        response = self.client.get(reverse("job_detail",
+                                           kwargs={"job_pk": self.job.pk}))
+        self.assertEqual(response.status_code, 404)
+
+    def test_publishing_a_source_does_not_publish_what_is_registered_on_it(self):
+        """A shared endpoint is not the same claim as shared data."""
+        from .models import ElementWPS
+        element = ElementWPS.objects.create(server=self.wps, identifier="carbon")
+        scope.claim(element, self.alice)
+
+        self.client.login(username="alice", password="alice-pw")
+        self.client.post(reverse("server_visibility",
+                                 kwargs={"server_type": "WPS",
+                                         "server_pk": self.wps.pk}))
+        self.wps.refresh_from_db()
+        self.assertTrue(self.wps.ownership.is_public)
+
+        # bob can now reach the source, but not the data registered on it.
+        self.assertIn(self.wps.server_ptr, scope.visible_servers(self.bob))
+        self.assertNotIn(element.serverelement_ptr,
+                         scope.visible_elements(self.bob))
+
+    def test_a_public_job_is_readable_but_not_runnable_by_a_stranger(self):
+        self.job.ownership.is_public = True
+        self.job.ownership.save()
+        self.client.login(username="bob", password="bob-pw")
+
+        self.assertEqual(
+            self.client.get(reverse("job_detail",
+                                    kwargs={"job_pk": self.job.pk})).status_code,
+            200)
+        # Readable is not runnable: job_run would submit someone else's work.
+        self.assertEqual(
+            self.client.get(reverse("job_run",
+                                    kwargs={"job_pk": self.job.pk})).status_code,
+            404)

--- a/tools/wpsclient/wpsclient/urls.py
+++ b/tools/wpsclient/wpsclient/urls.py
@@ -30,6 +30,14 @@ urlpatterns = [
     
     url(r'^server/(?P<server_type>'+server_type+')/(?P<server_pk>\d+)/check/$', views.server_check, name='server_check'),
 
+    # Before the element_id patterns above would otherwise be fine -- these end
+    # in a fixed segment, so they cannot be swallowed -- but keep them together
+    # with the other element routes for readability.
+    url(r'^server/(?P<server_type>'+server_type+r')/(?P<server_pk>\d+)/visibility/(?P<element_id>'+element_id+r')/$', views.element_visibility, name='element_visibility'),
+    # Before the element form above only by convention: element_id cannot be
+    # empty, so the two cannot collide.
+    url(r'^server/(?P<server_type>'+server_type+r')/(?P<server_pk>\d+)/visibility/$', views.server_visibility, name='server_visibility'),
+
     ##job specific urls
     url(r'^job/$', views.job_list, name='job_list'),
     #add server specific job list
@@ -55,5 +63,6 @@ urlpatterns = [
     url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/run/$', views.job_run, name='job_run'),
     url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/rerun/$', views.job_rerun, name='job_rerun'),
     url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/react/$', views.job_react, name='job_react'),
-    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/status/$', views.job_status, name='job_status'),    
+    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/status/$', views.job_status, name='job_status'),
+    url(r'^job/(?P<job_pk>[a-zA-Z0-9_:]+)/visibility/$', views.job_visibility, name='job_visibility'),
 ]

--- a/tools/wpsclient/wpsclient/views.py
+++ b/tools/wpsclient/wpsclient/views.py
@@ -22,6 +22,8 @@ from .models import Job
 from .models import ElementFingerprint
 from .models import ElementProvenance
 
+from . import scope
+
 from .forms import ServerFormCSV
 from .forms import ServerFormWCS
 from .forms import ServerFormWFS
@@ -77,15 +79,18 @@ else:
  
 # Create your views here.
 def dashboard(request):
-    servers_csv = ServerCSV.objects.order_by('title')
-    servers_wcs = ServerWCS.objects.order_by('title')
-    servers_wfs = ServerWFS.objects.order_by('title')
-    # A template is also a ServerWPS, so keep it out of the WPS list.
-    servers_wps = ServerWPS.objects.filter(servertemplate__isnull=True).order_by('title')
-    servers_tpl = ServerTemplate.objects.order_by('title')
+    def mine(queryset):
+        return scope.visible_servers(request.user, queryset).order_by('title')
 
-    process_jobs = Job.objects.order_by('pk')
-    
+    servers_csv = mine(ServerCSV.objects.all())
+    servers_wcs = mine(ServerWCS.objects.all())
+    servers_wfs = mine(ServerWFS.objects.all())
+    # A template is also a ServerWPS, so keep it out of the WPS list.
+    servers_wps = mine(ServerWPS.objects.filter(servertemplate__isnull=True))
+    servers_tpl = mine(ServerTemplate.objects.all())
+
+    process_jobs = scope.visible_jobs(request.user).order_by('pk')
+
     return render(request, 'wpsclient/dashboard.html', {'servers_csv' : servers_csv,
                                                         'servers_wcs' : servers_wcs,
                                                         'servers_wfs' : servers_wfs,
@@ -103,7 +108,8 @@ def server_list(request, server_type):
         }
 
     ServerClass = server_dict[server_type]
-    servers = ServerClass.objects.order_by('title')
+    servers = scope.visible_servers(request.user,
+                                    ServerClass.objects.all()).order_by('title')
     if server_type == "WPS":
         servers = servers.filter(servertemplate__isnull=True)
     return render(request, 'wpsclient/server_list.html',
@@ -119,13 +125,22 @@ def server_detail(request, server_pk, server_type):
         }
 
     ServerClass = server_dict[server_type]
-    
-    server = get_object_or_404(ServerClass, pk=server_pk)
 
-    process_jobs = Job.objects.filter(server__pk=server_pk).order_by('pk')
+    # 404 rather than 403 for a server this user may not see: a 403 would confirm
+    # that the row exists, which is the one thing scoping is meant to hide.
+    server = get_object_or_404(
+        scope.visible_servers(request.user, ServerClass.objects.all()),
+        pk=server_pk)
 
-    return render(request, 'wpsclient/server_detail.html', {'server': server,
-                                                            'process_list' : process_jobs})
+    process_jobs = scope.visible_jobs(
+        request.user, Job.objects.filter(server__pk=server_pk)).order_by('pk')
+
+    ownership = getattr(server, "ownership", None)
+    return render(request, 'wpsclient/server_detail.html',
+                  {'server': server,
+                   'process_list' : process_jobs,
+                   'is_public': bool(ownership and ownership.is_public),
+                   'may_modify': scope.may_modify(request.user, server)})
 
 ##def server_new(request, ows):
 ##    print(request.method, ows)
@@ -167,6 +182,11 @@ def server_register(request, server_type, title, url):
         server = ServerClass(title=title, url=url)
         server.save()
 
+    # Claimed after save, not before: the ownership row points at the server, so
+    # it needs a primary key. get_or_create in claim() keeps re-registration a
+    # no-op rather than transferring an existing owner.
+    scope.claim(server, request.user)
+
     return server_detail(request, server.pk, server_type)
 
 
@@ -185,7 +205,7 @@ def server_new(request, server_type):
         form = FormClass(request.POST)
         if form.is_valid():
             server = form.save()
-            #server.save()
+            scope.claim(server, request.user)
             return redirect('server_detail', server_pk=server.pk, server_type=server.server_type)
             
     else: #elif request.method == "GET"
@@ -233,8 +253,12 @@ def server_edit(request, server_pk, server_type):
         }
 
     ServerClass, FormClass = server_dict[server_type]
-    
-    server = get_object_or_404(ServerClass, pk=server_pk)
+
+    server = get_object_or_404(
+        scope.visible_servers(request.user, ServerClass.objects.all()),
+        pk=server_pk)
+    if not scope.may_modify(request.user, server):
+        raise Http404("no such server")
     if request.method == "POST":
         form = FormClass(request.POST, instance=server)
         if form.is_valid():
@@ -305,8 +329,16 @@ def get_wps_identifiers(server_url):
 
     return identifiers
 
-def get_server_element_register_list(server_pk):
-    return [element.identifier for element in ServerElement.objects.filter(server__pk=server_pk)]
+def get_server_element_register_list(server_pk, user=None):
+    """Identifiers of the elements registered against a server.
+
+    `user` scopes the list; omitting it returns every registered element, which
+    is what the internal callers (job argument choices) still want.
+    """
+    elements = ServerElement.objects.filter(server__pk=server_pk)
+    if user is not None:
+        elements = scope.visible_elements(user, elements)
+    return [element.identifier for element in elements]
     
 
 def server_element_list(request, server_type, server_pk):
@@ -320,11 +352,15 @@ def server_element_list(request, server_type, server_pk):
         }
 
     ServerClass, get_list = server_dict[server_type]
-    
-    server = get_object_or_404(ServerClass, pk=server_pk)
-    server_elements = ServerElement.objects.filter(server__pk=server_pk)
 
-    registered_element_list = get_server_element_register_list(server_pk)
+    server = get_object_or_404(
+        scope.visible_servers(request.user, ServerClass.objects.all()),
+        pk=server_pk)
+    server_elements = scope.visible_elements(
+        request.user, ServerElement.objects.filter(server__pk=server_pk))
+
+    registered_element_list = get_server_element_register_list(server_pk,
+                                                               request.user)
     registered_element_list.sort()
     
     unregistered_element_list = []
@@ -345,8 +381,22 @@ def server_element_list(request, server_type, server_pk):
         recorded = {f.element.identifier: f for f in
                     ElementFingerprint.objects.filter(
                         element__server__pk=server_pk).select_related("element")}
-    registered_rows = [(identifier, recorded.get(identifier))
-                       for identifier in registered_element_list]
+
+    # Public/private state per row, for the toggle. An element with no ownership
+    # row predates logins: it has no owner to publish it, so it is shown as
+    # neither public nor toggleable rather than as private-belonging-to-nobody.
+    owned = {e.identifier: e for e in server_elements.select_related("ownership")}
+    registered_rows = []
+    for identifier in registered_element_list:
+        element = owned.get(identifier)
+        ownership = getattr(element, "ownership", None) if element else None
+        registered_rows.append({
+            "identifier": identifier,
+            "fingerprint": recorded.get(identifier),
+            "is_public": bool(ownership and ownership.is_public),
+            "may_toggle": bool(element is not None
+                               and scope.may_modify(request.user, element)),
+        })
 
     return render(request, 'wpsclient/server_element_list.html', {'server': server,
                                                                   'registered_element_list' : registered_element_list,
@@ -371,6 +421,7 @@ def server_element_register(request, server_type, server_pk, element_id):
     # be a no-op, not a duplicate row in every dropdown.
     element, _created = ElementClass.objects.get_or_create(
         server=server, identifier=element_id)
+    scope.claim(element, request.user)
 
     server.registrations = server.registrations + 1
     server.save()
@@ -390,9 +441,20 @@ def server_element_unregister(request, server_type, server_pk, element_id):
     
     server = get_object_or_404(ServerClass, pk=server_pk)
 
-    element = ServerElement.objects.filter(server__pk=server_pk).filter(identifier=element_id).delete()
+    # Only what this user may see, and only what they may modify: seeing a public
+    # element is not licence to unregister someone else's.
+    doomed = [element for element
+              in scope.visible_elements(
+                  request.user,
+                  ServerElement.objects.filter(server__pk=server_pk,
+                                               identifier=element_id))
+              if scope.may_modify(request.user, element)]
+    if not doomed:
+        raise Http404("no such element")
+    for element in doomed:
+        element.delete()
 
-    server.registrations = server.registrations - 1
+    server.registrations = server.registrations - len(doomed)
     server.save()
 
     return server_element_list(request, server_type, server_pk)
@@ -490,27 +552,44 @@ def server_wps_element_detail(request, server_pk, element_id):
                                                                       'xml': description})    
 
 def server_job_list(request, server_pk):
-    process_jobs = Job.objects.filter(server__pk=server_pk).order_by('pk')
+    process_jobs = scope.visible_jobs(
+        request.user, Job.objects.filter(server__pk=server_pk)).order_by('pk')
     return render(request, 'wpsclient/job_list.html', {'process_list' : process_jobs})
 
 
 def job_list(request):
-    process_jobs = Job.objects.order_by('pk')
+    process_jobs = scope.visible_jobs(request.user).order_by('pk')
     return render(request, 'wpsclient/job_list.html', {'process_list' : process_jobs})
+
+
+def _modifiable_job(request, job_pk):
+    """A job this user may act on, or 404.
+
+    Visible-but-not-owned is not enough: a public job can be read by everyone,
+    and running, editing or re-running it is not reading. 404 rather than 403 so
+    the two cases are indistinguishable from outside.
+    """
+    job = get_object_or_404(scope.visible_jobs(request.user), pk=job_pk)
+    if not scope.may_modify(request.user, job):
+        raise Http404("no such job")
+    return job
 
 
 def job_detail(request, job_pk):
     l = logging.getLogger('django.request')
     l.warning(inspect.stack()[0][3])    
     #detail of an existing process with parameters
-    job = get_object_or_404(Job, pk=job_pk)
+    job = get_object_or_404(scope.visible_jobs(request.user), pk=job_pk)
+    ownership = getattr(job, "ownership", None)
     return render(request, 'wpsclient/job_detail.html',
                   {'job': job,
                    # Only a finished job is worth resubmitting; while it is still
                    # running, job_run is the poll.
                    'can_rerun': job.status in _JOB_FINISHED,
                    'unique_run': wants_unique_run(job),
-                   'reactive': wants_reaction(job)})
+                   'reactive': wants_reaction(job),
+                   'is_public': bool(ownership and ownership.is_public),
+                   'may_modify': scope.may_modify(request.user, job)})
 
 ##def job_new(request, server_pk, process_id):
 ##    server = get_object_or_404(ServerWPS, pk=server_pk)
@@ -618,6 +697,7 @@ def job_new_dynamic(request, server_pk, process_id, args):
         job = Job(server=server,identifier=process_id,args=args)
         job.status = "Validate"
         job.save()
+        scope.claim(job, request.user)
 
         server.jobs = server.jobs + 1
         server.save()
@@ -630,7 +710,7 @@ def job_new_dynamic(request, server_pk, process_id, args):
 
 def job_validate(request, job_pk):
 
-    job = get_object_or_404(Job, pk=job_pk)
+    job = _modifiable_job(request, job_pk)
     job.status = "Pending"
     job.save()
 
@@ -702,6 +782,24 @@ def anticipated_for_job(job):
     return out
 
 
+def _claim_for_job(element, job):
+    """An output belongs to whoever owns the job that produced it.
+
+    Jobs are created by a request and so have an owner; outputs are created by
+    reconciliation, which has no request to read one from. Without this an
+    output would be unowned, and unowned means admin-only -- so a user would run
+    a model and not see what it produced.
+
+    is_public is not copied from the job: visible_elements derives that through
+    ElementProvenance, so there is one flag to change rather than two to keep in
+    step.
+    """
+    owner = getattr(job, "ownership", None)
+    if owner is None:
+        return None
+    return scope.claim(element, owner.user)
+
+
 def register_pending(job):
     """List a job's anticipated outputs under the Local Pending sources."""
     if not any(job.args.get(field) for field in
@@ -716,8 +814,9 @@ def register_pending(job):
         # Scoped by job: two runs of one model anticipate identical names, and a
         # failed run's entries stay listed under its own job id.
         identifier = "job%s:%s" % (job.pk, name)
-        _element, created = ElementClass.objects.get_or_create(
+        element, created = ElementClass.objects.get_or_create(
             server=server, identifier=identifier)
+        _claim_for_job(element, job)
         added += int(created)
     return added
 
@@ -770,9 +869,12 @@ def reconcile_uploads(job, xml):
 
         element, created = ElementClass.objects.get_or_create(
             server=server, identifier=identifier)
+        _claim_for_job(element, job)
         registered += int(created)
 
         # Remember what made it, so the pipeline the jobs form can be drawn.
+        # Also what makes a public job publish its outputs: visible_elements
+        # reads this edge rather than a copy of the flag on each element.
         ElementProvenance.objects.update_or_create(
             element=element.serverelement_ptr, defaults={"job": job})
 
@@ -912,6 +1014,7 @@ def job_new(request, server_pk, process_id):
                                    for k, v in args.items())
             job.status_url = status_url
             job.save()
+            scope.claim(job, request.user)
 
             server.jobs = server.jobs + 1
             server.save()
@@ -930,8 +1033,8 @@ def job_new(request, server_pk, process_id):
 def job_edit(request, job_pk):
     l = logging.getLogger('django.request')
     l.warning(inspect.stack()[0][3])
-    
-    job = get_object_or_404(Job, pk=job_pk)
+
+    job = _modifiable_job(request, job_pk)
 
     if request.method == "POST":
         form = testForm(request.POST)        
@@ -1045,9 +1148,12 @@ def server_check(request, server_type, server_pk):
     if ServerClass is None:
         raise Http404("%s elements are not data" % server_type)
 
-    server = get_object_or_404(ServerClass, pk=server_pk)
+    server = get_object_or_404(
+        scope.visible_servers(request.user, ServerClass.objects.all()),
+        pk=server_pk)
     tally = {"changed": [], "unchanged": [], "unreachable": []}
-    for element in ServerElement.objects.filter(server__pk=server_pk):
+    for element in scope.visible_elements(
+            request.user, ServerElement.objects.filter(server__pk=server_pk)):
         try:
             tally[check_element(element, server_type)].append(element.identifier)
         except Exception as exc:  # noqa: BLE001 - one bad element must not stop the sweep
@@ -1161,19 +1267,27 @@ def react_to_changes(job):
     return "rerun", changed
 
 
-def _pipeline():
+def _pipeline(user):
     """The job pipeline as (nodes, edges), derived from what jobs consume and
-    produce. Nothing declares it -- see tools/job_graph.py."""
+    produce. Nothing declares it -- see tools/job_graph.py.
+
+    Drawn from the jobs this user may see, so the diagram is their pipeline
+    rather than a picture of how many runs everyone else has.
+    """
     tools = "/app/tools"
     if tools not in sys.path:
         sys.path.insert(0, tools)
     import job_graph
 
+    jobs = list(scope.visible_jobs(user).order_by("pk"))
+
+    # Edges only between the jobs in the diagram: an edge to a job that was
+    # filtered out would draw a node for it and leak its identifier.
+    visible_ids = {job.pk for job in jobs}
     produced_by = {}
     for record in ElementProvenance.objects.select_related("element"):
-        produced_by[record.element.identifier] = record.job_id
-
-    jobs = list(Job.objects.order_by("pk"))
+        if record.job_id in visible_ids:
+            produced_by[record.element.identifier] = record.job_id
     inputs_of = {}
     for job in jobs:
         inputs_of[job.pk] = [element.identifier
@@ -1183,7 +1297,7 @@ def _pipeline():
 
 def job_graph_view(request):
     """The pipeline the jobs form, drawn."""
-    module, (nodes, edges) = _pipeline()
+    module, (nodes, edges) = _pipeline(request.user)
     return render(request, "wpsclient/job_graph.html",
                   {"diagram": module.to_mermaid(nodes, edges),
                    "job_count": len(nodes), "edge_count": len(edges)})
@@ -1191,7 +1305,7 @@ def job_graph_view(request):
 
 def job_graph_bpmn(request):
     """The same pipeline as BPMN 2.0, for a modeller such as bpmn.io."""
-    module, (nodes, edges) = _pipeline()
+    module, (nodes, edges) = _pipeline(request.user)
     response = HttpResponse(module.to_bpmn(nodes, edges),
                             content_type="application/xml")
     response["Content-Disposition"] = 'attachment; filename="esws-pipeline.bpmn"'
@@ -1200,7 +1314,7 @@ def job_graph_bpmn(request):
 
 def job_react(request, job_pk):
     """Check one job's inputs and re-run it if they changed."""
-    job = get_object_or_404(Job, pk=job_pk)
+    job = _modifiable_job(request, job_pk)
     action, changed = react_to_changes(job)
     if action == "rerun":
         return redirect("job_run", job_pk=job.pk)
@@ -1215,7 +1329,7 @@ def job_react_all(request):
     than one. Meant to be reachable from cron as well as from the page.
     """
     results = []
-    for job in Job.objects.order_by("pk"):
+    for job in scope.visible_jobs(request.user).order_by("pk"):
         if not wants_reaction(job):
             continue
         action, changed = react_to_changes(job)
@@ -1302,7 +1416,7 @@ def job_rerun(request, job_pk):
     option set, this run gets a fresh suffix and the previous run's outputs stay
     where they are instead of being overwritten.
     """
-    job = get_object_or_404(Job, pk=job_pk)
+    job = _modifiable_job(request, job_pk)
     job.status = "Run"
     job.status_location = ""
     rotate_run_token(job)
@@ -1318,7 +1432,7 @@ def job_status(request, job_pk):
     job's outcome becomes known -- and, once uploads are wired up, where
     anticipated outputs get reconciled against what was really produced.
     """
-    job = get_object_or_404(Job, pk=job_pk)
+    job = _modifiable_job(request, job_pk)
 
     xml = ""
     if job.status_location:
@@ -1352,7 +1466,7 @@ def job_status(request, job_pk):
 
 
 def job_run(request, job_pk):
-    job = get_object_or_404(Job, pk=job_pk)
+    job = _modifiable_job(request, job_pk)
 
     if job.status == "Validate":
         job.status = "Run"
@@ -1410,3 +1524,100 @@ def job_run(request, job_pk):
 
 
     
+
+
+def element_visibility(request, server_type, server_pk, element_id):
+    """Toggle whether a registered element is public.
+
+    POST only: it changes what other people can see, so it must not be reachable
+    by following a link or by a page prefetching one.
+
+    An element produced by a public job is public through that job (see
+    scope.visible_elements), and this toggle does not override it -- turning the
+    job private is what makes its outputs private again. Otherwise one element
+    could be marked private while remaining visible, and the page would show a
+    state that is not the truth.
+    """
+    if request.method != "POST":
+        raise Http404("not a page")
+
+    element = get_object_or_404(
+        scope.visible_elements(
+            request.user,
+            ServerElement.objects.filter(server__pk=server_pk,
+                                         identifier=element_id)))
+    if not scope.may_modify(request.user, element):
+        raise Http404("no such element")
+
+    ownership = getattr(element, "ownership", None)
+    if ownership is None:
+        # Unowned and modifiable means an admin is looking at a row that
+        # predates logins. Publishing it would leave it owned by nobody and
+        # unpublishable again, so claim it for them first.
+        ownership = scope.claim(element, request.user)
+        if ownership is None:
+            raise Http404("no such element")
+
+    ownership.is_public = not ownership.is_public
+    ownership.save(update_fields=["is_public"])
+
+    return redirect("server_element_list", server_type=server_type,
+                    server_pk=server_pk)
+
+
+def job_visibility(request, job_pk):
+    """Toggle whether a job -- and with it every output it produced -- is public."""
+    if request.method != "POST":
+        raise Http404("not a page")
+
+    job = _modifiable_job(request, job_pk)
+    ownership = getattr(job, "ownership", None)
+    if ownership is None:
+        ownership = scope.claim(job, request.user)
+        if ownership is None:
+            raise Http404("no such job")
+
+    ownership.is_public = not ownership.is_public
+    ownership.save(update_fields=["is_public"])
+
+    return redirect("job_detail", job_pk=job.pk)
+
+
+def server_visibility(request, server_type, server_pk):
+    """Toggle whether a source is public.
+
+    Not in the original brief, which asked for a toggle per registered element,
+    but without it the scoping has no way to become usable: sources are scoped
+    like everything else, so a new account sees no servers, and a user who
+    cannot see the shared WPS source cannot open its process list or run
+    anything at all. Publishing the source is what an administrator does once;
+    the per-element toggle then governs the data.
+
+    Making a source public does not publish the elements registered on it --
+    those carry their own flag, and a shared endpoint is not the same claim as
+    shared data.
+    """
+    if request.method != "POST":
+        raise Http404("not a page")
+
+    server_dict = {"CSV": ServerCSV, "WCS": ServerWCS, "WFS": ServerWFS,
+                   "WPS": ServerWPS, "TPL": ServerTemplate}
+    ServerClass = server_dict[server_type]
+
+    server = get_object_or_404(
+        scope.visible_servers(request.user, ServerClass.objects.all()),
+        pk=server_pk)
+    if not scope.may_modify(request.user, server):
+        raise Http404("no such server")
+
+    ownership = getattr(server, "ownership", None)
+    if ownership is None:
+        ownership = scope.claim(server, request.user)
+        if ownership is None:
+            raise Http404("no such server")
+
+    ownership.is_public = not ownership.is_public
+    ownership.save(update_fields=["is_public"])
+
+    return redirect("server_detail", server_type=server_type,
+                    server_pk=server_pk)


### PR DESCRIPTION
The dashboard had no login at all: every visitor saw every server, element and
job, and could run or delete any of them. This makes it multi-user — an admin
sees everything, exactly as before, and everyone else sees what they own plus
what has been shared.

### Why Django owns identity and not GeoServer

GeoServer validates a login cleanly. One Basic-auth request to
`/rest/about/version` answers both questions at once (verified live against
3.0.0):

| credentials | response | meaning |
|---|---|---|
| valid, `ADMIN` | **200** | admin view |
| valid, non-admin (incl. `GROUP_ADMIN`) | **403** | scoped view |
| wrong password | **401** | reject |
| **disabled** account | **401** | reject |

**But this image cannot hold the users.** `/opt/startup.sh` →
`handle_geoserver_admin_credentials.sh` → `update_credentials.sh` overwrites
`users.xml` and `roles.xml` from the webapp's pristine templates on every start,
keeping only admin:

```sh
cat $USERS_XML_ORIG | sed -e "s/ name=\".*\" /.../" > $TMP_USERS
mv $TMP_USERS $USERS_XML      # unconditional
```

It runs whenever `GEOSERVER_ADMIN_USER` + `GEOSERVER_ADMIN_PASSWORD` are set, and
`docker-compose.yml` always sets both. I found this by creating a user and a role
through the REST API (201/200) and watching both vanish across
`docker compose restart`. GeoServer cannot be the system of record here.

### Ownership is three new tables, not three new columns

`MIGRATION_MODULES = {'wpsclient': None}` and `migrate --run-syncdb` — which
creates a missing table but cannot ALTER an existing one. The same constraint
already put `ElementFingerprint` and `ElementProvenance` in tables of their own.
Confirmed the three tables are created with every column:

```
wpsclient_serverowner  CREATED  ['id','user_id','is_public','created_at','server_id']
wpsclient_elementowner CREATED  ['id','user_id','is_public','created_at','element_id']
wpsclient_jobowner     CREATED  ['id','user_id','is_public','created_at','job_id']
```

Those tables inherit the constraint, so their fields are decided in one pass —
adding one later would need yet another table.

### The rules, in one module

All of it lives in `wpsclient/scope.py` rather than in 60-odd views:

- **admin** sees everything (the pre-account behaviour, preserved)
- **owner** sees what they created
- **public** is visible to anyone signed in
- **a public job publishes its outputs** — *derived*, not copied.
  `ElementProvenance` already records which job made an element, so this is a
  join: one flag to change instead of two to keep in step.
- **unowned rows are admin-only** — rows predating accounts match none of the
  clauses, so this needs no special case.

### Default-deny, and a test that keeps it that way

`LoginRequiredMiddleware` rather than 60-odd decorators: a forgotten decorator
serves another user's data; a forgotten exemption is a login prompt someone
reports on day one. `test_every_view_requires_a_login` walks the urlconf and
asserts every route redirects, so a view added later is covered when it is
added — plus a guard against the enumeration silently yielding nothing.

### One addition beyond the brief

You asked for a toggle per registered element, and for a public job to publish
its outputs — both are here. I also added a **source** toggle, because without it
the design does not function: sources are scoped too, so a new account sees no
servers, and a user who cannot see the shared WPS source cannot open its process
list or run anything at all. Publishing a source deliberately does *not* publish
the elements registered on it; a shared endpoint is not the same claim as shared
data, and there's a test for that.

### Latent bugs that turning logins on exposed

Four templates had branches inside `{% if user.is_authenticated %}` that had
never once rendered, because nobody could sign in. All four reversed
`server_edit` without its required `server_type`, so they 500'd the moment a
user logged in. `server_detail.html`'s job table also called `job_detail` with
`process_pk` instead of `job_pk` and referenced two routes that do not exist
(`server_describe_process`, `server_capabilities`) — that loop only renders when
a server has jobs, which is how it survived. Fixed rather than left, since this
change puts those pages in front of people.

`scripts/load_demo.py` registers over HTTP and would have followed the redirect
to the login form, reporting HTTP 200 having registered nothing — a silent
no-op. It signs in first now. The stack tests likewise run as the administrator.

### Verification

Against the running stack, with the demo loaded (10 sources, 127 elements):

| | sources visible | jobs visible |
|---|---|---|
| new non-admin (`carla`) | **0** | **0** |
| after admin publishes one source | **1** | 0 |
| admin | all | all |

- **20** Django tests (`manage.py test wpsclient`) — scoping rules, the toggle's
  POST-only and owner-only behaviour, and the urlconf sweep.
- **85 passed, 0 skipped** for the full stack suite with the demo loaded. The
  seven "needs the demo loaded" skips were made to run rather than left skipping.
- `tests/unit` still 52; CI's byte-compile step clean.

### Note for deployment

`DEBUG = True` is still set in `settings.py` — untouched here because it is not
part of this change, but it should go before this is exposed to real users. The
first admin comes from `DASHBOARD_ADMIN_USER`/`DASHBOARD_ADMIN_PASS` (defaults
`admin` / `esws-admin`); everyone else is created at `/admin/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWfVxbSMiA9BZ68yce9ymR
